### PR TITLE
Revert "xenvm: dom0: add section for U-boot binary and device tree"

### DIFF
--- a/cmake/linker_script/common/common-ram.cmake
+++ b/cmake/linker_script/common/common-ram.cmake
@@ -17,18 +17,6 @@ zephyr_linker_section_configure(SECTION device_states
   KEEP INPUT ".z_devstate" ".z_devstate.*"
 )
 
-if(CONFIG_XEN_INITIAL_DOMAIN)
-zephyr_linker_section(NAME uboot_domu GROUP DATA_REGION)
-zephyr_linker_section_configure(SECTION uboot_domu
-  KEEP INPUT ".uboot_domu""
-)
-
-zephyr_linker_section(NAME dtb_domu GROUP DATA_REGION)
-zephyr_linker_section_configure(SECTION dtb_domu
-  KEEP INPUT ".dtb_domu""
-)
-endif()
-
 if(CONFIG_PM_DEVICE)
   zephyr_linker_section(NAME pm_device_slots GROUP DATA_REGION TYPE NOLOAD NOINPUT ${XIP_ALIGN_WITH_INPUT})
   zephyr_linker_section_configure(SECTION pm_device_slots KEEP INPUT ".z_pm_device_slots")

--- a/include/zephyr/linker/common-ram.ld
+++ b/include/zephyr/linker/common-ram.ld
@@ -36,24 +36,6 @@
                 __device_states_end = .;
         } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
-#if defined(CONFIG_XEN_INITIAL_DOMAIN)
-        SECTION_DATA_PROLOGUE(img_domd,,)
-        {
-		. = ALIGN(64);
-               __img_domd_start = .;
-               KEEP(*(".img_domd"));
-               __img_domd_end = .;
-        } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-
-	SECTION_DATA_PROLOGUE(dtb_domd,,)
-	{
-		. = ALIGN(64);
-               __dtb_domd_start = .;
-               KEEP(*(".dtb_domd"));
-               __dtb_domd_end = .;
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-#endif
-
 #if CONFIG_PM_DEVICE
 	SECTION_DATA_PROLOGUE(pm_device_slots, (NOLOAD),)
 	{


### PR DESCRIPTION
This reverts commit a2090fde38534c7078f81074649e46684240c10a.

Adding new section by patching linker scripts in mainline is a bad approach. It was needed to keep domain binaries inside zephyr dom0 image and now we moved them to data section. It was made by app code and does not require any changes here, so we remove this changes from Zephyr OS.