### PR TITLE
FOR SQUASH: events.h: add missing function declaration

### DIFF
--- a/include/zephyr/xen/events.h
+++ b/include/zephyr/xen/events.h
@@ -37,6 +37,15 @@ int notify_evtchn(evtchn_port_t port);
 int alloc_unbound_event_channel(domid_t remote_dom);
 
 /*
+ * Allocate event-channel between remote domains. Can be used only from Dom0.
+ *
+ * @param dom - first remote domain domid (may be DOMID_SELF)
+ * @param remote_dom - second remote domain domid
+ * @return - local event channel port on success, negative on error
+ */
+int alloc_unbound_event_channel_dom0(domid_t dom, domid_t remote_dom);
+
+/*
  * Allocate local event channel, binded to remote port and attach specified callback
  * to it
  *


### PR DESCRIPTION
This commit adds missing declaration for Dom0-specific alloc function. It was introduced by e977c4ba2670f and should be squashed with this commit during migration to main branch.