### PR TITLE
boards: arm64: match hypervisor unit-address address in the reg property

### DIFF
--- a/boards/arm64/xenvm/xenvm.dts
+++ b/boards/arm64/xenvm/xenvm.dts
@@ -68,7 +68,7 @@
 		interrupt-parent = <&gic>;
 	};
 
-	hypervisor: hypervisor@38000000 {
+	hypervisor: hypervisor@48200000 {
 		compatible = "xen,xen-4.15", "xen,xen";
 		reg = <0x00 0x48200000 0x00 0x1000000>;
 		interrupts = <GIC_PPI 0x0 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;


### PR DESCRIPTION
The "hypervisor" unit-address must match the first address specified in the reg property of the node.