### PR TITLE
boards: arm64 h3ulcb: changed type of board to mcu

### DIFF
--- a/boards/arm64/rcar_h3ulcb_ca57/rcar_h3ulcb_ca57.yaml
+++ b/boards/arm64/rcar_h3ulcb_ca57/rcar_h3ulcb_ca57.yaml
@@ -1,6 +1,6 @@
 identifier: rcar_h3ulcb_ca57
 name: Renesas H3ULCB based on r8a7795
-type: rcar
+type: mcu
 arch: arm64
 toolchain:
   - zephyr


### PR DESCRIPTION
* change type of board from unknown 'rcar' to 'mcu', because without this change twister Zephyr tests is failing.