### PR TITLE
boards: shields: xenvm_dom0: fix building grant tables

### DIFF
--- a/boards/shields/xenvm_dom0/Kconfig.defconfig
+++ b/boards/shields/xenvm_dom0/Kconfig.defconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 EPAm Systems
+# SPDX-License-Identifier: Apache-2.0
+
+if SHIELD_XENVM_DOM0
+
+config HEAP_MEM_POOL_SIZE
+	default 2097152
+
+endif # SHIELD_XENVM_DOM0


### PR DESCRIPTION
Config XEN_GRANT_TABLE isn't enabled in case when we have a heap pool size is equal to zero. So, for XenVM dom0 shield we should add config of HEAP_MEM_POOL_SIZE in order to get grant tables enabled.