### PR TITLE
drivers: rcar_mmc: add support of SCC tuning

### DIFF
--- a/drivers/sdhc/Kconfig.rcar
+++ b/drivers/sdhc/Kconfig.rcar
@@ -20,6 +20,12 @@ config RCAR_MMC_DMA_SUPPORT
 	help
 	  Internal DMA support for Renesas Rcar MMC driver.
 
+config RCAR_MMC_SCC_SUPPORT
+	bool "Support of SCC"
+	default y
+	help
+	  Enable support of Sampling Clock Controller for Renesas Rcar MMC driver.
+
 if RCAR_MMC_DMA_SUPPORT
 
 config SDHC_BUFFER_ALIGNMENT

--- a/drivers/sdhc/rcar_mmc.c
+++ b/drivers/sdhc/rcar_mmc.c
@@ -1189,7 +1189,7 @@ static int rcar_mmc_set_clk_rate(const struct device *dev,
 
 	host_io->clock = ios->clock;
 
-	LOG_INF("%s: set clock rate to %d",
+	LOG_DBG("%s: set clock rate to %d",
 		dev->name, ios->clock);
 
 	return 0;
@@ -1271,7 +1271,7 @@ static int rcar_mmc_set_bus_width(const struct device *dev,
 
 	host_io->bus_width = ios->bus_width;
 
-	LOG_INF("%s: set bus-width to %d", dev->name, host_io->bus_width);
+	LOG_DBG("%s: set bus-width to %d", dev->name, host_io->bus_width);
 	return 0;
 }
 

--- a/drivers/sdhc/rcar_mmc_registers.h
+++ b/drivers/sdhc/rcar_mmc_registers.h
@@ -192,12 +192,27 @@
 
 /* set of SCC registers */
 
+/* Initial setting register */
+#define RENESAS_SDHI_SCC_DTCNTL			0x1000
+#define RENESAS_SDHI_SCC_DTCNTL_TAPEN		BIT(0)
+/* Sampling clock position setting register */
+#define RENESAS_SDHI_SCC_TAPSET			0x1008
+#define RENESAS_SDHI_SCC_DT2FF			0x1010
 /* Sampling Clock Selection Register */
 #define RENESAS_SDHI_SCC_CKSEL			0x1018
 #define RENESAS_SDHI_SCC_CKSEL_DTSEL		BIT(0)
 /* Sampling Clock Position Correction Register */
 #define RENESAS_SDHI_SCC_RVSCNTL		0x1020
 #define RENESAS_SDHI_SCC_RVSCNTL_RVSEN		BIT(0)
+/* Sampling Clock Position Correction Request Register */
+#define RENESAS_SDHI_SCC_RVSREQ			0x1028
+#define RENESAS_SDHI_SCC_RVSREQ_REQTAPDOWN	BIT(0)
+#define RENESAS_SDHI_SCC_RVSREQ_REQTAPUP	BIT(1)
+#define RENESAS_SDHI_SCC_RVSREQ_REQTAP_MASK \
+	(RENESAS_SDHI_SCC_RVSREQ_REQTAPDOWN | RENESAS_SDHI_SCC_RVSREQ_REQTAPUP)
+#define RENESAS_SDHI_SCC_RVSREQ_ERR		BIT(2)
+/* Sampling data comparison register */
+#define RENESAS_SDHI_SCC_SMPCMP			0x1030
 /* Hardware Adjustment Register 2, used for configuration HS400 mode */
 #define RENESAS_SDHI_SCC_TMPPORT2		0x1038
 #define RENESAS_SDHI_SCC_TMPPORT2_HS400EN	BIT(31)


### PR DESCRIPTION
Enable using of sampling clock controller. When using SCC, it is necessary to perform tuning to determine the tap position of the received clock. Currenlty, tuning is performed only for `hs200` and `sdr104` timings.