### PR TITLE
fixups for SD clock, DMAC and reset

### DIFF
--- a/drivers/sdhc/rcar_mmc.c
+++ b/drivers/sdhc/rcar_mmc.c
@@ -293,12 +293,6 @@ static int rcar_mmc_reset(const struct device *dev)
 
 	data = dev->data;
 
-	ret = rcar_mmc_poll_reg_flags_check_err(dev, RCAR_MMC_INFO2,
-				RCAR_MMC_INFO2_CBSY, 0, false, false);
-	if (ret) {
-		return -ETIMEDOUT;
-	}
-
 	/*
 	 * soft reset of the host
 	 */

--- a/drivers/sdhc/rcar_mmc.c
+++ b/drivers/sdhc/rcar_mmc.c
@@ -1109,7 +1109,7 @@ static int rcar_mmc_set_clk_rate(const struct device *dev,
 	}
 
 	divisor = round_up_next_pwr_of_2(divisor);
-	if (divisor == 0) {
+	if (divisor == 1) {
 		divisor = RCAR_MMC_CLKCTL_RCAR_DIV1;
 	} else {
 		divisor >>= 2;

--- a/drivers/sdhc/rcar_mmc.c
+++ b/drivers/sdhc/rcar_mmc.c
@@ -1603,7 +1603,7 @@ static const struct sdhc_driver_api rcar_sdhc_api = {
 };
 
 /**
- * @brief Start SD-IF2 clock at 200MHz
+ * @brief Start SD-IF clock at max frequency configured in dts
  *
  * @param cfg The Renesas MMC driver configuration
  *

--- a/drivers/sdhc/rcar_mmc_registers.h
+++ b/drivers/sdhc/rcar_mmc_registers.h
@@ -175,6 +175,9 @@
 #define RCAR_MMC_DMA_MODE_ADDR_INC	BIT(0)	/* 1: address inc, 0: fixed */
 #define RCAR_MMC_DMA_CTL		0x828
 #define RCAR_MMC_DMA_CTL_START		BIT(0)	/* start DMA (auto cleared) */
+#define RCAR_MMC_DMA_RST		0x830
+#define RCAR_MMC_DMA_RST_DTRAN0		BIT(8)
+#define RCAR_MMC_DMA_RST_DTRAN1		BIT(9)
 #define RCAR_MMC_DMA_INFO1		0x840
 #define RCAR_MMC_DMA_INFO1_END_RD2	BIT(20)	/* DMA from device is complete (uniphier) */
 #define RCAR_MMC_DMA_INFO1_END_RD	BIT(17)	/* DMA from device is complete (renesas) */


### PR DESCRIPTION
    Add reset of MMC DMAC in case of DMA errors and to SDHC reset function.

    Fix description of 'rcar_mmc_init_start_clk' function.

    There isn't any sense to wait when RCAR_MMC_INFO2_CBSY flag is cleared,
    because reset function can be called for case when MMC controller stucks
    due to this flag.

    SD clock divider is set incorrectly for case when it is needed to supply
    from SDϕ without division.