### PR TITLE
boards: shields: Set memory bank to the free memory for rcar_spider

### DIFF
--- a/boards/shields/xenvm_dom0/boards/rcar_spider.overlay
+++ b/boards/shields/xenvm_dom0/boards/rcar_spider.overlay
@@ -7,8 +7,8 @@
 /delete-node/ &ram;
 
 / {
-	ram: memory@60000000 {
+	ram: memory@80000000 {
 		device_type = "mmio-sram";
-		reg = <0x00 0x60000000 0x00 DT_SIZE_M(256)>;
+		reg = <0x00 0x80000000 0x00 DT_SIZE_M(256)>;
 	};
 };


### PR DESCRIPTION
According to the commit d3218a4df ("arm64: dts: renesas: r8a779f0: spider-cpu: Reserve memory for Realtime core"), added by Phong Hoang to the renesas kernel [0], the last 512MB of the first memory bank is reserved for CR.
So we have to move ram address to bank2 so it will not overlap the existing memory.

[0] https://github.com/renesas-rcar/linux-bsp.git