### PR TITLE
arch: arm64: mmu: avoid using of set/way cache instructions for Xen

### DIFF
--- a/include/zephyr/arch/arm64/cache.h
+++ b/include/zephyr/arch/arm64/cache.h
@@ -28,19 +28,35 @@ extern int arm64_dcache_all(int op);
 
 extern size_t arch_dcache_line_size_get(void);
 
+#ifdef CONFIG_DT_HAS_XEN_XEN_ENABLED
+extern int flush_inv_mapped_tbls(int (*cache_op)(void *, size_t));
+#endif
+
 int ALWAYS_INLINE arch_dcache_flush_all(void)
 {
+#ifdef CONFIG_DT_HAS_XEN_XEN_ENABLED
+	return flush_inv_mapped_tbls(arch_dcache_flush_range);
+#else
 	return arm64_dcache_all(K_CACHE_WB);
+#endif
 }
 
 int ALWAYS_INLINE arch_dcache_invd_all(void)
 {
+#ifdef CONFIG_DT_HAS_XEN_XEN_ENABLED
+	return flush_inv_mapped_tbls(arch_dcache_invd_range);
+#else
 	return arm64_dcache_all(K_CACHE_INVD);
+#endif
 }
 
 int ALWAYS_INLINE arch_dcache_flush_and_invd_all(void)
 {
+#ifdef CONFIG_DT_HAS_XEN_XEN_ENABLED
+	return flush_inv_mapped_tbls(arch_dcache_flush_and_invd_range);
+#else
 	return arm64_dcache_all(K_CACHE_WB_INVD);
+#endif
 }
 
 int ALWAYS_INLINE arch_dcache_flush_range(void *addr, size_t size)


### PR DESCRIPTION
**NOTE: changes have been tested only on h3ulcb board**

Exposing set/way cache maintenance to a virtual machine is unsafe, not
least because the instructions are not permission-checked, but also
because they are not broadcast between CPUs.

Unfortunately, set/way ops are not easily virtualized by Xen. S/W
emulation is disabled, because IP-MMU is active for Dom0. IP-MMU is
a IO-MMU made by Renesas, as any good IO-MMU, it shares page-tables
with CPU. Trying to emulate S/W with IP-MMU active will lead to
IO-MMU faults. So if we build Zephyr as a Xen Initial domain, it
won't work with cache management support enabled.

In this commit, VA data invalidate of mapped pages is used instead of
using set/way instructions. So, it might slightly increase system
initialization time.