### PR TITLE
drivers: tee: optee: Introducing OPTEE_RPC_CMD function handles 

### DIFF
--- a/drivers/tee/optee/Kconfig
+++ b/drivers/tee/optee/Kconfig
@@ -11,3 +11,11 @@ config OPTEE
 	  Driver requests functions from the OP-TEE and implements RPC mechanism
 	  needed by OP-TEE to run services. See https://www.op-tee.org for more
 	  information.
+
+config OPTEE_MAX_NOTIF
+	int "Max number of OP-TEE notifications"
+	depends on OPTEE
+	default 255
+	help
+	 Sets the maximum notifications from OP-TEE to the Normal World. OP-TEE using
+	 this mechanism for the synchronization.

--- a/drivers/tee/optee/optee_rpc_cmd.h
+++ b/drivers/tee/optee/optee_rpc_cmd.h
@@ -1,0 +1,106 @@
+/* SPDX-License-Identifier: Apache-2 */
+/*
+ * Copyright (c) 2016-2021, Linaro Limited
+ */
+
+#ifndef __OPTEE_RPC_CMD_H
+#define __OPTEE_RPC_CMD_H
+
+/*
+ * All RPC is done with a struct optee_msg_arg as bearer of information,
+ * struct optee_msg_arg::arg holds values defined by OPTEE_RPC_CMD_* below.
+ * Only the commands handled by the kernel driver are defined here.
+ *
+ * RPC communication with tee-supplicant is reversed compared to normal
+ * client communication described above. The supplicant receives requests
+ * and sends responses.
+ */
+
+/*
+ * Get time
+ *
+ * Returns number of seconds and nano seconds since the Epoch,
+ * 1970-01-01 00:00:00 +0000 (UTC).
+ *
+ * [out]    value[0].a	    Number of seconds
+ * [out]    value[0].b	    Number of nano seconds.
+ */
+#define OPTEE_RPC_CMD_GET_TIME		3
+
+/*
+ * Notification from/to secure world.
+ *
+ * If secure world needs to wait for something, for instance a mutex, it
+ * does a notification wait request instead of spinning in secure world.
+ * Conversely can a synchronous notification can be sent when a secure
+ * world mutex with a thread waiting thread is unlocked.
+ *
+ * This interface can also be used to wait for a asynchronous notification
+ * which instead is sent via a non-secure interrupt.
+ *
+ * Waiting on notification
+ * [in]    value[0].a	    OPTEE_RPC_NOTIFICATION_WAIT
+ * [in]    value[0].b	    notification value
+ *
+ * Sending a synchronous notification
+ * [in]    value[0].a	    OPTEE_RPC_NOTIFICATION_SEND
+ * [in]    value[0].b	    notification value
+ */
+#define OPTEE_RPC_CMD_NOTIFICATION	4
+#define OPTEE_RPC_NOTIFICATION_WAIT	0
+#define OPTEE_RPC_NOTIFICATION_SEND	1
+
+/*
+ * Suspend execution
+ *
+ * [in]    value[0].a	Number of milliseconds to suspend
+ */
+#define OPTEE_RPC_CMD_SUSPEND		5
+
+/*
+ * Allocate a piece of shared memory
+ *
+ * [in]    value[0].a	    Type of memory one of
+ *			    OPTEE_RPC_SHM_TYPE_* below
+ * [in]    value[0].b	    Requested size
+ * [in]    value[0].c	    Required alignment
+ * [out]   memref[0]	    Buffer
+ */
+#define OPTEE_RPC_CMD_SHM_ALLOC		6
+/* Memory that can be shared with a non-secure user space application */
+#define OPTEE_RPC_SHM_TYPE_APPL		0
+/* Memory only shared with non-secure kernel */
+#define OPTEE_RPC_SHM_TYPE_KERNEL	1
+
+/*
+ * Free shared memory previously allocated with OPTEE_RPC_CMD_SHM_ALLOC
+ *
+ * [in]     value[0].a	    Type of memory one of
+ *			    OPTEE_RPC_SHM_TYPE_* above
+ * [in]     value[0].b	    Value of shared memory reference or cookie
+ */
+#define OPTEE_RPC_CMD_SHM_FREE		7
+
+/*
+ * Issue master requests (read and write operations) to an I2C chip.
+ *
+ * [in]     value[0].a	    Transfer mode (OPTEE_RPC_I2C_TRANSFER_*)
+ * [in]     value[0].b	    The I2C bus (a.k.a adapter).
+ *				16 bit field.
+ * [in]     value[0].c	    The I2C chip (a.k.a address).
+ *				16 bit field (either 7 or 10 bit effective).
+ * [in]     value[1].a	    The I2C master control flags (ie, 10 bit address).
+ *				16 bit field.
+ * [in/out] memref[2]	    Buffer used for data transfers.
+ * [out]    value[3].a	    Number of bytes transferred by the REE.
+ */
+#define OPTEE_RPC_CMD_I2C_TRANSFER	21
+
+/* I2C master transfer modes */
+#define OPTEE_RPC_I2C_TRANSFER_RD	0
+#define OPTEE_RPC_I2C_TRANSFER_WR	1
+
+/* I2C master control flags */
+#define OPTEE_RPC_I2C_FLAGS_TEN_BIT	BIT(0)
+
+#endif /*__OPTEE_RPC_CMD_H*/

--- a/tests/drivers/tee/optee/src/main.c
+++ b/tests/drivers/tee/optee/src/main.c
@@ -19,6 +19,7 @@
 #include <zephyr/drivers/tee.h>
 #include <optee_msg.h>
 #include <optee_smc.h>
+#include <optee_rpc_cmd.h>
 
 /*
  * TODO: Test shm_register/shm_register API to work with huge
@@ -322,6 +323,315 @@ ZTEST(optee_test_suite, test_reg_unreg)
 	t_call.num = 0;
 	ret = tee_shm_free(dev, shm);
 	zassert_ok(ret, "tee_shm_free failed with code %d", ret);
+}
+
+static uint64_t regs_to_u64(uint32_t reg0, uint32_t reg1)
+{
+	return (uint64_t)(((uint64_t)reg0 << 32) | reg1);
+}
+
+static void u64_to_regs(uint64_t val, unsigned long *reg0, unsigned long *reg1)
+{
+	*reg0 = val >> 32;
+	*reg1 = val;
+}
+
+uint64_t g_shm_ref;
+uint64_t g_func_shm_ref;
+
+void cmd_alloc_free_call(unsigned long a0, unsigned long a1, unsigned long a2, unsigned long a3,
+			 unsigned long a4, unsigned long a5, unsigned long a6, unsigned long a7,
+			 struct arm_smccc_res *res)
+{
+	struct optee_msg_arg *arg;
+	struct tee_shm *shm;
+
+	t_call.a0 = a0;
+	t_call.a1 = a1;
+	t_call.a2 = a2;
+	t_call.a3 = a3;
+	t_call.a4 = a4;
+	t_call.a5 = a5;
+	t_call.a6 = a6;
+	t_call.a7 = a7;
+
+	res->a1 = a1;
+	res->a2 = a2;
+	res->a3 = a3;
+	res->a4 = a4;
+	res->a5 = a5;
+
+	switch (t_call.num) {
+	case 0:
+		res->a0 = OPTEE_SMC_RETURN_RPC_PREFIX | OPTEE_SMC_RPC_FUNC_ALLOC;
+		res->a1 = 1;
+		break;
+	case 1:
+		zassert_equal(a0, 0x32000003, "%s failed with ret %lx", __func__, a0);
+		res->a0 = OPTEE_SMC_RETURN_RPC_PREFIX | OPTEE_SMC_RPC_FUNC_CMD;
+		arg = (struct optee_msg_arg *)regs_to_u64(a1, a2);
+		arg->cmd = OPTEE_RPC_CMD_SHM_ALLOC;
+		arg->num_params = 1;
+		arg->params[0].attr = OPTEE_MSG_ATTR_TYPE_VALUE_INPUT;
+		arg->params[0].u.value.b = 4096;
+		arg->params[0].u.value.a = OPTEE_RPC_SHM_TYPE_KERNEL;
+		res->a1 = a4;
+		res->a2 = a5;
+		g_shm_ref = regs_to_u64(a4, a5);
+		break;
+	case 2:
+		zassert_equal(a0, 0x32000003, "%s failed with ret %lx", __func__, a0);
+		res->a0 = OPTEE_SMC_RETURN_RPC_PREFIX | OPTEE_SMC_RPC_FUNC_CMD;
+		printk("a1 %lx, a2 %lx a4 %lx a5 %lx\n", a1, a2);
+		shm = (struct tee_shm *)regs_to_u64(a1, a2);
+		arg = (struct optee_msg_arg *)shm->addr;
+		arg->cmd = OPTEE_RPC_CMD_SHM_FREE;
+		arg->num_params = 1;
+		arg->params[0].attr = OPTEE_MSG_ATTR_TYPE_VALUE_INPUT;
+		arg->params[0].u.value.a = OPTEE_RPC_SHM_TYPE_KERNEL;
+		arg->params[0].u.value.b = g_func_shm_ref;
+		u64_to_regs(g_shm_ref, &res->a1, &res->a2);
+		break;
+	case 3:
+		zassert_equal(a0, 0x32000003, "%s failed with ret %lx", __func__, a0);
+		u64_to_regs(g_shm_ref, &res->a1, &res->a2);
+		res->a0 = OPTEE_SMC_RETURN_RPC_PREFIX | OPTEE_SMC_RPC_FUNC_FREE;
+		break;
+	case 4:
+		zassert_equal(a0, 0x32000003, "%s failed with ret %lx", __func__, a0);
+		res->a0 = OPTEE_SMC_RETURN_OK;
+		break;
+	default:
+		zassert_equal(a0, 0x32000003, "%s failed with ret %lx", __func__, a0);
+		res->a0 = OPTEE_SMC_RETURN_OK;
+	}
+
+	t_call.num++;
+}
+
+ZTEST(optee_test_suite, test_func_shm_alloc)
+{
+	int ret;
+	uint32_t session_id;
+	struct tee_open_session_arg arg = {};
+	struct tee_invoke_func_arg invoke_arg = {};
+	struct tee_param param = {};
+	const struct device *const dev = DEVICE_DT_GET_ONE(linaro_optee_tz);
+
+	zassert_not_null(dev, "Unable to get dev");
+
+	t_call.num = 0;
+	t_call.smc_cb = fast_call;
+
+	arg.uuid[0] = 111;
+	arg.clnt_uuid[0] = 222;
+	arg.clnt_login = TEEC_LOGIN_PUBLIC;
+	param.attr = TEE_PARAM_ATTR_TYPE_NONE;
+	param.a = 3333;
+	ret = tee_open_session(dev, &arg, 1, &param, &session_id);
+	zassert_ok(ret, "tee_open_session failed with code %d", ret);
+
+	t_call.num = 0;
+	t_call.smc_cb = cmd_alloc_free_call;
+
+	invoke_arg.func = 12;
+	invoke_arg.session = 1;
+	ret = tee_invoke_func(dev, &invoke_arg, 1, &param);
+	zassert_ok(ret, "tee_invoke_fn failed with code %d", ret);
+
+	t_call.num = 0;
+	t_call.smc_cb = fast_call;
+
+	ret = tee_close_session(dev, session_id);
+	zassert_ok(ret, "close_session failed with code %d", ret);
+}
+
+void cmd_gettime_call(unsigned long a0, unsigned long a1, unsigned long a2, unsigned long a3,
+		      unsigned long a4, unsigned long a5, unsigned long a6, unsigned long a7,
+		      struct arm_smccc_res *res)
+{
+	struct optee_msg_arg *arg;
+	struct tee_shm *shm;
+
+	res->a1 = a1;
+	res->a2 = a2;
+	res->a3 = a3;
+	res->a4 = a4;
+	res->a5 = a5;
+
+	switch (t_call.num) {
+	case 0:
+		res->a0 = OPTEE_SMC_RETURN_RPC_PREFIX | OPTEE_SMC_RPC_FUNC_ALLOC;
+		res->a1 = 1;
+		break;
+	case 1:
+		zassert_equal(a0, 0x32000003, "%s failed with ret %lx", __func__, a0);
+		res->a0 = OPTEE_SMC_RETURN_RPC_PREFIX | OPTEE_SMC_RPC_FUNC_CMD;
+		arg = (struct optee_msg_arg *)regs_to_u64(a1, a2);
+		arg->cmd = OPTEE_RPC_CMD_GET_TIME;
+		arg->num_params = 1;
+		arg->params[0].attr = OPTEE_MSG_ATTR_TYPE_VALUE_OUTPUT;
+		res->a1 = a4;
+		res->a2 = a5;
+		g_shm_ref = regs_to_u64(a4, a5);
+		break;
+	case 2:
+		zassert_equal(a0, 0x32000003, "%s failed with ret %lx", __func__, a0);
+		res->a0 = OPTEE_SMC_RETURN_RPC_PREFIX | OPTEE_SMC_RPC_FUNC_FREE;
+		shm = (struct tee_shm *)regs_to_u64(a1, a2);
+		arg = (struct optee_msg_arg *)shm->addr;
+
+		t_call.a6 = arg->params[0].u.value.a;
+		t_call.a7 = arg->params[0].u.value.b;
+		u64_to_regs(g_shm_ref, &res->a1, &res->a2);
+		break;
+	case 3:
+		zassert_equal(a0, 0x32000003, "%s failed with ret %lx", __func__, a0);
+		res->a0 = OPTEE_SMC_RETURN_OK;
+		break;
+	default:
+		zassert_equal(a0, 0x32000003, "%s failed with ret %lx", __func__, a0);
+		res->a0 = OPTEE_SMC_RETURN_OK;
+	}
+
+	t_call.num++;
+}
+
+#define TICKS 0xDEADBEEF
+#define TEST_SEC 37359285
+#define TEST_NSEC 590000000
+extern void z_vrfy_sys_clock_tick_set(uint64_t tick);
+
+ZTEST(optee_test_suite, test_gettime)
+{
+	int ret;
+	uint32_t session_id;
+	struct tee_open_session_arg arg = {};
+	struct tee_invoke_func_arg invoke_arg = {};
+	struct tee_param param = {};
+	const struct device *const dev = DEVICE_DT_GET_ONE(linaro_optee_tz);
+
+	zassert_not_null(dev, "Unable to get dev");
+
+	t_call.num = 0;
+	t_call.smc_cb = fast_call;
+
+	arg.uuid[0] = 111;
+	arg.clnt_uuid[0] = 222;
+	arg.clnt_login = TEEC_LOGIN_PUBLIC;
+	param.attr = TEE_PARAM_ATTR_TYPE_NONE;
+	param.a = 3333;
+	ret = tee_open_session(dev, &arg, 1, &param, &session_id);
+	zassert_ok(ret, "tee_open_session failed with code %d", ret);
+
+	t_call.num = 0;
+	t_call.smc_cb = cmd_gettime_call;
+
+	z_vrfy_sys_clock_tick_set(TICKS);
+
+	invoke_arg.func = 12;
+	invoke_arg.session = 1;
+	ret = tee_invoke_func(dev, &invoke_arg, 1, &param);
+	zassert_ok(ret, "tee_invoke_fn failed with code %d", ret);
+
+	zassert_equal(t_call.a6, TEST_SEC, "Unexpected secs");
+	zassert_equal(t_call.a7, TEST_NSEC, "Unexpected nsecs");
+
+	t_call.num = 0;
+	t_call.smc_cb = fast_call;
+
+	ret = tee_close_session(dev, session_id);
+	zassert_ok(ret, "close_session failed with code %d", ret);
+}
+
+void cmd_suspend_call(unsigned long a0, unsigned long a1, unsigned long a2, unsigned long a3,
+		      unsigned long a4, unsigned long a5, unsigned long a6, unsigned long a7,
+		      struct arm_smccc_res *res)
+{
+	struct optee_msg_arg *arg;
+	struct tee_shm *shm;
+
+	res->a1 = a1;
+	res->a2 = a2;
+	res->a3 = a3;
+	res->a4 = a4;
+	res->a5 = a5;
+
+	switch (t_call.num) {
+	case 0:
+		res->a0 = OPTEE_SMC_RETURN_RPC_PREFIX | OPTEE_SMC_RPC_FUNC_ALLOC;
+		res->a1 = 1;
+		break;
+	case 1:
+		zassert_equal(a0, 0x32000003, "%s failed with ret %lx", __func__, a0);
+		res->a0 = OPTEE_SMC_RETURN_RPC_PREFIX | OPTEE_SMC_RPC_FUNC_CMD;
+		arg = (struct optee_msg_arg *)regs_to_u64(a1, a2);
+		arg->cmd = OPTEE_RPC_CMD_SUSPEND;
+		arg->num_params = 1;
+		arg->params[0].attr = OPTEE_MSG_ATTR_TYPE_VALUE_INPUT;
+		arg->params[0].u.value.a = t_call.a0;
+		res->a1 = a4;
+		res->a2 = a5;
+		g_shm_ref = regs_to_u64(a4, a5);
+		break;
+	case 2:
+		zassert_equal(a0, 0x32000003, "%s failed with ret %lx", __func__, a0);
+		res->a0 = OPTEE_SMC_RETURN_RPC_PREFIX | OPTEE_SMC_RPC_FUNC_FREE;
+		shm = (struct tee_shm *)regs_to_u64(a1, a2);
+		arg = (struct optee_msg_arg *)shm->addr;
+
+		t_call.a6 = arg->params[0].u.value.a;
+		t_call.a7 = arg->params[0].u.value.b;
+		u64_to_regs(g_shm_ref, &res->a1, &res->a2);
+		break;
+	case 3:
+		zassert_equal(a0, 0x32000003, "%s failed with ret %lx", __func__, a0);
+		res->a0 = OPTEE_SMC_RETURN_OK;
+		break;
+	default:
+		zassert_equal(a0, 0x32000003, "%s failed with ret %lx", __func__, a0);
+		res->a0 = OPTEE_SMC_RETURN_OK;
+	}
+
+	t_call.num++;
+}
+
+ZTEST(optee_test_suite, test_suspend)
+{
+	int ret;
+	uint32_t session_id;
+	struct tee_open_session_arg arg = {};
+	struct tee_invoke_func_arg invoke_arg = {};
+	struct tee_param param = {};
+	const struct device *const dev = DEVICE_DT_GET_ONE(linaro_optee_tz);
+
+	zassert_not_null(dev, "Unable to get dev");
+
+	t_call.num = 0;
+	t_call.smc_cb = fast_call;
+
+	arg.uuid[0] = 111;
+	arg.clnt_uuid[0] = 222;
+	arg.clnt_login = TEEC_LOGIN_PUBLIC;
+	param.attr = TEE_PARAM_ATTR_TYPE_NONE;
+	param.a = 3333;
+	ret = tee_open_session(dev, &arg, 1, &param, &session_id);
+	zassert_ok(ret, "tee_open_session failed with code %d", ret);
+
+	t_call.num = 0;
+	t_call.a0 = 4000; /* Set timeout 4000 ms */
+	t_call.smc_cb = cmd_suspend_call;
+
+	invoke_arg.func = 12;
+	invoke_arg.session = 1;
+	ret = tee_invoke_func(dev, &invoke_arg, 1, &param);
+	zassert_ok(ret, "tee_invoke_fn failed with code %d", ret);
+
+	t_call.num = 0;
+	t_call.smc_cb = fast_call;
+
+	ret = tee_close_session(dev, session_id);
+	zassert_ok(ret, "close_session failed with code %d", ret);
 }
 
 ZTEST_SUITE(optee_test_suite, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
This includes the implementation of the basic RPC_CMD which are received from OP-TEE TA service. Memory allocation requests, gettime and suspend were implemented in this commit.
This PR was reviewed and approved in my fork. Recreated it on top of xen-troops/zephyr repo.