### PR TITLE
drivers: tee: optee: Implementation of the multiple Optee driver nodes support

### DIFF
--- a/drivers/tee/optee/optee.c
+++ b/drivers/tee/optee/optee.c
@@ -1139,9 +1139,9 @@ static int optee_init(const struct device *dev)
 	 */
 
 	sys_dlist_init(&data->notif);
-	k_mutex_init(&optee_data.supp.mutex);
-	k_sem_init(&optee_data.supp.reqs_c, 0, 1);
-	sys_dlist_init(&optee_data.supp.reqs);
+	k_mutex_init(&data->supp.mutex);
+	k_sem_init(&data->supp.reqs_c, 0, 1);
+	sys_dlist_init(&data->supp.reqs);
 
 	return 0;
 }

--- a/tests/drivers/tee/optee/src/main.c
+++ b/tests/drivers/tee/optee/src/main.c
@@ -66,6 +66,13 @@ void arm_smccc_smc(unsigned long a0, unsigned long a1, unsigned long a2, unsigne
 	}
 }
 
+/* Allocate dummy arm_smccc_hvc function for the tests */
+void arm_smccc_hvc(unsigned long a0, unsigned long a1, unsigned long a2, unsigned long a3,
+		   unsigned long a4, unsigned long a5, unsigned long a6, unsigned long a7,
+		   struct arm_smccc_res *res)
+{
+}
+
 ZTEST(optee_test_suite, test_get_version)
 {
 	int ret;


### PR DESCRIPTION
The implementation of the multiple Optee driver nodes support for the driver.
This will help handling the situation, which is possible, according to the GP documentation:
[ TEE1 ] -> [ REE (Zephyr) ] <- [ TEE2 ]
Although there is no real case for now, this approach has a better fitment to Zephyr driver model.