### PR TITLE
drivers: tee: Introduce shm memory registry API

### DIFF
--- a/drivers/tee/tee_priv.h
+++ b/drivers/tee/tee_priv.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 EPAM Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef _TEE_PRIV_H_
+#define _TEE_PRIV_H_
+
+#include <zephyr/device.h>
+
+/**
+ * @brief Registers shm object in the registry list
+ *
+ * Register shm object in external list. Expecting list to be properly initialized.
+ * This function registers tee_shm which were allocated in terms of the session, such
+ * as invoke_fn call, all allocation calls from TEE and doesn't cover shm_alloc or
+ * shm_register syscalls because this memory is supposed to be requested by client and
+ * do not have any information about session so system wouldn't know at which point this
+ * memory should be freed. That's why those resources should be managed by client itself.
+ *
+ * @param list Pointer to the initialized dlist object, stored in client driver data
+ * @param shm Shared memory object pointer to register
+ * @param session_id Current session id
+ */
+int tee_shm_list_reg(sys_dlist_t *list, struct tee_shm *shm, uint32_t session_id);
+
+/**
+ * @brief Unregisters shm object from the registry list
+ *
+ * Should be called just before freeing shm object.
+ *
+ * @param list Pointer to the initialized dlist object, stored in client driver data
+ * @param shm Shared memory object pointer to register
+ */
+void tee_shm_list_unreg(sys_dlist_t *list, struct tee_shm *shm);
+
+/**
+ * @brief Cleaning up shm objects that wasn't cleaned
+ *
+ * Should be called before closing session to clean all remaining shm objects.
+ *
+ * @param list Pointer to the initialized dlist object, stored in client driver data
+ * @param session_id Current session id
+ */
+void tee_shm_session_clean(sys_dlist_t *list, uint32_t session_id);
+
+#endif /* _TEE_PRIV_H_ */

--- a/include/zephyr/drivers/tee.h
+++ b/include/zephyr/drivers/tee.h
@@ -266,16 +266,25 @@ struct tee_invoke_func_arg {
 
 /**
  * struct tee_shm - tee shared memory structure
+ *
+ * Tee shared memory @node property stores link to dlist which is tracking
+ * all shm object allocated in terms of the @session. This list helps to clean up
+ * resources that weren't removed by TEE before closing @session.
+ *
  * @dev:        [out] Pointer to the device driver structure
  * @addr:       [out] Shared buffer pointer
  * @size:       [out] Shared buffer size
  * @flags:      [out] Shared buffer flags
+ * @session:    [out] Session_id which shm is registered to
+ * @node:       [out] Link to shm registry
  */
 struct tee_shm {
 	const struct device *dev;
 	void *addr;
 	uint64_t size;
 	uint32_t flags;
+	uint32_t session;
+	sys_dnode_t node;
 };
 
 /**

--- a/tests/drivers/tee/optee/src/main.c
+++ b/tests/drivers/tee/optee/src/main.c
@@ -62,6 +62,10 @@ void arm_smccc_smc(unsigned long a0, unsigned long a1, unsigned long a2, unsigne
 		res->a3 = OPTEE_MSG_UID_3;
 		return;
 	}
+	if (a0 == OPTEE_SMC_EXCHANGE_CAPABILITIES) {
+		res->a1 = OPTEE_SMC_SEC_CAP_DYNAMIC_SHM;
+		return;
+	}
 	if (t_call.pending && t_call.smc_cb) {
 		t_call.smc_cb(a0, a1, a2, a3, a4, a5, a6, a7, res);
 	}

--- a/tests/drivers/tee/optee/src/main.c
+++ b/tests/drivers/tee/optee/src/main.c
@@ -55,6 +55,13 @@ void arm_smccc_smc(unsigned long a0, unsigned long a1, unsigned long a2, unsigne
 		   unsigned long a4, unsigned long a5, unsigned long a6, unsigned long a7,
 		   struct arm_smccc_res *res)
 {
+	if (a0 == OPTEE_SMC_CALLS_UID) {
+		res->a0 = OPTEE_MSG_UID_0;
+		res->a1 = OPTEE_MSG_UID_1;
+		res->a2 = OPTEE_MSG_UID_2;
+		res->a3 = OPTEE_MSG_UID_3;
+		return;
+	}
 	if (t_call.pending && t_call.smc_cb) {
 		t_call.smc_cb(a0, a1, a2, a3, a4, a5, a6, a7, res);
 	}

--- a/tests/drivers/tee/optee/src/main.c
+++ b/tests/drivers/tee/optee/src/main.c
@@ -257,11 +257,11 @@ void normal_call(unsigned long a0, unsigned long a1, unsigned long a2, unsigned 
 	switch (t_call.num) {
 	case 0:
 		res->a0 = OPTEE_SMC_RETURN_RPC_PREFIX | OPTEE_SMC_RPC_FUNC_ALLOC;
-		res->a1 = a1;
-		res->a2 = a2;
+		res->a1 = a4;
+		res->a2 = a5;
 		res->a3 = a3;
-		res->a4 = a4;
-		res->a5 = a5;
+		res->a4 = 0;
+		res->a5 = 0;
 		break;
 	case 1:
 		zassert_equal(a0, 0x32000003, "%s failed with ret %lx", __func__, a0);


### PR DESCRIPTION
    Tee subsystem can receive request from TEE OS to allocate memory,
    which is represented by tee_shm object. Tee subsystem should keep
    track of the allocated tee_shm object in terms of some session to be
    able to clean remaining objects, which where not released by TEE OS
    before closing session.
    This API is tracking only objects, allocated in terms of some session
    and do not track objects, allocated using syscalls tee_shm_alloc and
    tee_shm_register because they are not connected to the specific
    session and should be managed by caller.