### PR TITLE
tests: drivers: optee: Add CAPS and UID to the unit tests

### DIFF
--- a/tests/drivers/tee/optee/src/main.c
+++ b/tests/drivers/tee/optee/src/main.c
@@ -62,6 +62,10 @@ void arm_smccc_smc(unsigned long a0, unsigned long a1, unsigned long a2, unsigne
 		res->a3 = OPTEE_MSG_UID_3;
 		return;
 	}
+	if (a0 == OPTEE_SMC_EXCHANGE_CAPABILITIES) {
+		res->a1 = OPTEE_SMC_SEC_CAP_DYNAMIC_SHM;
+		return;
+	}
 	if (t_call.pending && t_call.smc_cb) {
 		t_call.smc_cb(a0, a1, a2, a3, a4, a5, a6, a7, res);
 	}

--- a/tests/drivers/tee/optee/src/main.c
+++ b/tests/drivers/tee/optee/src/main.c
@@ -55,6 +55,13 @@ void arm_smccc_smc(unsigned long a0, unsigned long a1, unsigned long a2, unsigne
 		   unsigned long a4, unsigned long a5, unsigned long a6, unsigned long a7,
 		   struct arm_smccc_res *res)
 {
+	if (a0 == OPTEE_SMC_CALLS_UID) {
+		res->a0 = OPTEE_MSG_UID_0;
+		res->a1 = OPTEE_MSG_UID_1;
+		res->a2 = OPTEE_MSG_UID_2;
+		res->a3 = OPTEE_MSG_UID_3;
+		return;
+	}
 	if (t_call.pending && t_call.smc_cb) {
 		t_call.smc_cb(a0, a1, a2, a3, a4, a5, a6, a7, res);
 	}

--- a/tests/drivers/tee/optee/src/main.c
+++ b/tests/drivers/tee/optee/src/main.c
@@ -257,11 +257,11 @@ void normal_call(unsigned long a0, unsigned long a1, unsigned long a2, unsigned 
 	switch (t_call.num) {
 	case 0:
 		res->a0 = OPTEE_SMC_RETURN_RPC_PREFIX | OPTEE_SMC_RPC_FUNC_ALLOC;
-		res->a1 = a1;
-		res->a2 = a2;
+		res->a1 = a4;
+		res->a2 = a5;
 		res->a3 = a3;
-		res->a4 = a4;
-		res->a5 = a5;
+		res->a4 = 0;
+		res->a5 = 0;
 		break;
 	case 1:
 		zassert_equal(a0, 0x32000003, "%s failed with ret %lx", __func__, a0);


### PR DESCRIPTION
Optee driver checks CAPS and UID during initialization, so the unit tests should provide valid data during callback execution or otherwise error message should be printed.
Also fixed the behavour of RPC_FUNC_ALLOC. Optee-os expects new shm address on a3 and a4 and then moves it to a1 a2 when executing other calls, such as RPC_FUNC_FREE. Made normal_call behavior the save as in OP-TEE