### PR TITLE
drivers: tee: optee: Introduce SHM caching mechanism to the optee driver

### DIFF
--- a/drivers/tee/optee/Kconfig
+++ b/drivers/tee/optee/Kconfig
@@ -19,3 +19,15 @@ config OPTEE_MAX_NOTIF
 	help
 	 Sets the maximum notifications from OP-TEE to the Normal World. OP-TEE using
 	 this mechanism for the synchronization.
+
+config OPTEE_SHM_CACHE_MAX_ENTRIES
+	int "Upper limit of SHM cache entries"
+	depends on OPTEE
+	default 16
+	help
+	  This sets the maximum number of entries in the SHM cache. SHM allocator
+	  would not allocate more than this number of entries. This effectively
+	  limits the number of OPTEE requests that can be in flight at any given
+	  time. This is needed to prevent the possibility of causing a memory
+	  leak by doing a large number of requests in parallel. The default value
+	  of 16 should be sufficient for most use cases.

--- a/tests/drivers/tee/optee/src/main.c
+++ b/tests/drivers/tee/optee/src/main.c
@@ -62,6 +62,10 @@ void arm_smccc_smc(unsigned long a0, unsigned long a1, unsigned long a2, unsigne
 		res->a3 = OPTEE_MSG_UID_3;
 		return;
 	}
+	if (a0 == OPTEE_SMC_DISABLE_SHM_CACHE) {
+		res->a0 = OPTEE_SMC_RETURN_ENOTAVAIL;
+		return;
+	}
 	if (a0 == OPTEE_SMC_EXCHANGE_CAPABILITIES) {
 		res->a1 = OPTEE_SMC_SEC_CAP_DYNAMIC_SHM;
 		return;


### PR DESCRIPTION
This PR introduces the following features:
1) Enables shm_cache in OP-TEE to reduce SHM objects allocation. Decision whether to use shm_cache or not is done based on the capabilities exchange
2) SHM object cache which allow reusing SHM objects to store rpc args. Also concurrent calls can share SHM object memory by using different offsets. This allows to reduce alloc/free operation because for the most cases one SHM object is enogh.