### PR TITLE
toolchain: use proper binary operation for #if directive

### DIFF
--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -94,7 +94,7 @@
 #define FUNC_ALIAS(real_func, new_alias, return_type) \
 	return_type new_alias() ALIAS_OF(real_func)
 
-#if defined(CONFIG_ARCH_POSIX) and !defined(_ASMLANGUAGE)
+#if defined(CONFIG_ARCH_POSIX) && !defined(_ASMLANGUAGE)
 #include <zephyr/arch/posix/posix_trace.h>
 
 /*let's not segfault if this were to happen for some reason*/


### PR DESCRIPTION
"#if" directive expects usage of binary operations in "&&" format, not "and". Change it to fix build failure.

Fixes: "toolchain: do not use posix C code for asm language in gcc.h"