### PR TITLE
drivers: tee: optee: Use arch_page_phys_get for address conversion

### DIFF
--- a/drivers/tee/optee/CMakeLists.txt
+++ b/drivers/tee/optee/CMakeLists.txt
@@ -4,3 +4,5 @@
 zephyr_library()
 
 zephyr_library_sources(optee.c)
+
+zephyr_library_include_directories(${ZEPHYR_BASE}/arch/${ARCH}/include)

--- a/drivers/tee/optee/Kconfig
+++ b/drivers/tee/optee/Kconfig
@@ -3,7 +3,7 @@
 
 config OPTEE
 	bool "OP-TEE driver"
-	depends on ARM64 || ZTEST
+	depends on (ARM64 && MMU) || ZTEST
 	help
 	  This implements support of the OP-TEE firmware which is loaded
 	  as BL32 image. OP-TEE is a Trust Zone OS which implements mechanisms


### PR DESCRIPTION
According to the description of z_mem_phys_addr it uses Z_MEM_VM_OFFSET to make a conversion from virtual to physical address. And these macros are intended for assembly, linker code, and static initializers.
So when external libraries, such as PICOLIBC or NEWLIB_LIBC uses internal mappings for dynamic memory allocation z_mem_phys_addr may not work properly and return wrong physical address.

We have met this problem when testing work with MBEDTLS to generate certificate using PKCS11 in libckteec.
Mbedtls allocates buffer dynamically and ivokes tee command to request certificate from PKCS11 TA which should place result to the allocated buffer.
The result is the MBEDTLS is used with minimal libc - then everything works fine. But when CONFIG_PICOLIBC or CONFIG_NEWLIB_LIBC is enabled
- it returns empty buffer. This happens because z_mem_phys_addr returns incorrect physical address.