### PR TITLE
Github action fixes for xentroops repo

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   contribs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Manifest
     steps:
       - name: Checkout the code

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Manifest
         uses: zephyrproject-rtos/action-manifest@a6d0c6e52bbbb7d6df23ceb42842edcb4582b8dc
         with:
-          github-token: ${{ secrets.ZB_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           manifest-path: 'west.yml'
           checkout-path: 'zephyrproject/zephyr'
           label-prefix: 'manifest-'


### PR DESCRIPTION
One of Zephyr actions for Github (Manifest) constantly failed for our repo, causing CI become red for every PR. As we are still running Zephyr v3.3.0 we needed to fix it on our side.

(This PR will fail too since Github Actions uses routines from base branch, test PR with new routines is here - https://github.com/xen-troops/zephyr/pull/85)