### PR TITLE
drivers: ramdisk: Add support for external initrd

### DIFF
--- a/drivers/disk/Kconfig.ram
+++ b/drivers/disk/Kconfig.ram
@@ -14,7 +14,8 @@ config DISK_RAM_VOLUME_SIZE
 	int "RAM Disk size in kilobytes"
 	default 96
 	help
-	  Size of the RAM Disk.
+	  Size of the RAM Disk. If compression is supported, this
+	  is the maximum size of the uncompressed RAM Disk.
 
 config DISK_RAM_VOLUME_NAME
 	string "RAM Disk mount point or drive name"
@@ -33,6 +34,12 @@ config DISK_RAM_START
 	default 0
 	help
 	  Start the RAM Disk at a specific address.
+
+config DISK_RAM_DECOMPRESS
+	bool "Decompress the initrd"
+	depends on DISK_RAM_EXTERNAL && LZ4
+	help
+	  Decompress the initrd before using it as the RAM Disk.
 
 module = RAMDISK
 module-str = ramdisk

--- a/drivers/disk/Kconfig.ram
+++ b/drivers/disk/Kconfig.ram
@@ -22,6 +22,18 @@ config DISK_RAM_VOLUME_NAME
 	help
 	  Disk name as per file system naming guidelines.
 
+config DISK_RAM_EXTERNAL
+	bool "Use initrd provided by the bootloader"
+	help
+	  Use the initrd provided by the bootloader as the RAM Disk.
+
+config DISK_RAM_START
+	hex "Start address of the preloaded RAM Disk"
+	depends on DISK_RAM_EXTERNAL
+	default 0
+	help
+	  Start the RAM Disk at a specific address.
+
 module = RAMDISK
 module-str = ramdisk
 source "subsys/logging/Kconfig.template.log_config"

--- a/modules/lz4/CMakeLists.txt
+++ b/modules/lz4/CMakeLists.txt
@@ -11,6 +11,8 @@ if(CONFIG_LZ4)
 
   zephyr_library_sources(
     ${LZ4_DIR}/lib/lz4.c
+    ${LZ4_DIR}/lib/lz4frame.c
+    ${LZ4_DIR}/lib/xxhash.c
   )
 
 endif()


### PR DESCRIPTION
Add support for using initrd provided by the bootloader. Supports both compressed and uncompressed filesystem images.