### PR TITLE
drivers: serial: Disable interrupts in SCIF driver

### DIFF
--- a/drivers/input/input_ft5336.c
+++ b/drivers/input/input_ft5336.c
@@ -75,7 +75,7 @@ struct ft5336_config {
 	struct gpio_dt_spec reset_gpio;
 	int tag;
 #ifdef CONFIG_INPUT_FT5336_INTERRUPT
-#ifdef CONFIG_FT5335_GPIO_INTERRUPT
+#ifdef CONFIG_INPUT_FT5335_GPIO_INTERRUPT
 	/** Interrupt GPIO information. */
 	struct gpio_dt_spec int_gpio;
 #else


### PR DESCRIPTION
Disable interrupts in SCIF driver after DMA operation finished. If interrupts remains enabled it leads to hangs in ISR.