### PR TITLE
xen: align ram bank 0 configuration with libxl

### DIFF
--- a/include/zephyr/xen/public/arch-arm.h
+++ b/include/zephyr/xen/public/arch-arm.h
@@ -436,8 +436,8 @@ typedef uint64_t xen_callback_t;
 
 #define GUEST_RAM_BANKS                        2
 
-#define GUEST_RAM0_BASE                        xen_mk_ullong(0x40000000) /* 3GB of low RAM @ 1GB */
-#define GUEST_RAM0_SIZE                        xen_mk_ullong(0xc0000000)
+#define GUEST_RAM0_BASE                        xen_mk_ullong(0x40000000) /* 2GB of low RAM @ 1GB */
+#define GUEST_RAM0_SIZE                        xen_mk_ullong(0x80000000)
 
 #define GUEST_RAM1_BASE                        xen_mk_ullong(0x0200000000) /* 1016GB of RAM @ 8GB */
 #define GUEST_RAM1_SIZE                        xen_mk_ullong(0xfe00000000)


### PR DESCRIPTION
Align GUEST_RAM0_SIZE with value in libxl.

Ensure that the first extended region does not overlap with devices memory addresses.

Changes have been synced with the 'xen-4.19-xt0.1' branch on the https://github.com/xen-troops/xen.git repository.