### PR TITLE
xenvm: dom0: update Xen public headers for running Zephyr as Dom0

### DIFF
--- a/include/zephyr/xen/public/arch-arm.h
+++ b/include/zephyr/xen/public/arch-arm.h
@@ -364,6 +364,13 @@ struct xen_arch_domainconfig {
 	uint16_t tee_type;
 	/* IN */
 	uint32_t nr_spis;
+#if __XEN_INTERFACE_VERSION__ >= 0x00041300
+	/**
+	 * IN
+	 * OSID used by virtual GSX device.
+	 */
+	uint8_t vgsx_osid;
+#endif
 	/*
 	 * OUT
 	 * Based on the property clock-frequency in the DT timer node.
@@ -495,6 +502,23 @@ typedef uint64_t xen_callback_t;
 #define GUEST_VPCI_MEM_SIZE                 xen_mk_ullong(0x10000000)
 
 /*
+ * 16 MB is reserved for virtio-pci configuration space based on calculation
+ * 8 bridges * 2 buses x 32 devices x 8 functions x 4 KB = 16 MB
+ */
+#define GUEST_VIRTIO_PCI_ECAM_BASE          xen_mk_ullong(0x33000000)
+#define GUEST_VIRTIO_PCI_TOTAL_ECAM_SIZE    xen_mk_ullong(0x01000000)
+#define GUEST_VIRTIO_PCI_HOST_ECAM_SIZE     xen_mk_ullong(0x00200000)
+
+/* 64 MB is reserved for virtio-pci memory */
+#define GUEST_VIRTIO_PCI_ADDR_TYPE_MEM    xen_mk_ullong(0x02000000)
+#define GUEST_VIRTIO_PCI_MEM_ADDR         xen_mk_ullong(0x34000000)
+#define GUEST_VIRTIO_PCI_MEM_SIZE         xen_mk_ullong(0x04000000)
+
+/* Guest TPM device */
+#define GUEST_TPM_BASE    xen_mk_ullong(0x0c000000)
+#define GUEST_TPM_SIZE    xen_mk_ullong(0x00005000)
+
+/*
  * 16MB == 4096 pages reserved for guest to use as a region to map its
  * grant table in.
  */
@@ -503,6 +527,10 @@ typedef uint64_t xen_callback_t;
 
 #define GUEST_MAGIC_BASE               xen_mk_ullong(0x39000000)
 #define GUEST_MAGIC_SIZE               xen_mk_ullong(0x01000000)
+/* 64 MB is reserved for virtio-pci Prefetch memory */
+#define GUEST_VIRTIO_PCI_ADDR_TYPE_PREFETCH_MEM    xen_mk_ullong(0x42000000)
+#define GUEST_VIRTIO_PCI_PREFETCH_MEM_ADDR         xen_mk_ullong(0x3a000000)
+#define GUEST_VIRTIO_PCI_PREFETCH_MEM_SIZE         xen_mk_ullong(0x04000000)
 
 #define GUEST_RAM_BANKS                        2
 
@@ -535,6 +563,9 @@ typedef uint64_t xen_callback_t;
 #define GUEST_VPL011_SPI               32
 #define GUEST_VIRTIO_MMIO_SPI_FIRST   33
 #define GUEST_VIRTIO_MMIO_SPI_LAST    43
+
+#define GUEST_VIRTIO_PCI_SPI_FIRST   44
+#define GUEST_VIRTIO_PCI_SPI_LAST    76
 
 /* PSCI functions */
 #define PSCI_cpu_suspend               0

--- a/include/zephyr/xen/public/arch-arm/hvm/save.h
+++ b/include/zephyr/xen/public/arch-arm/hvm/save.h
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: MIT */
+
+/******************************************************************************
+ * Structure definitions for HVM state that is held by Xen and must
+ * be saved along with the domain's memory and device-model state.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Copyright (c) 2012 Citrix Systems Ltd.
+ */
+
+#ifndef __XEN_PUBLIC_HVM_SAVE_ARM_H__
+#define __XEN_PUBLIC_HVM_SAVE_ARM_H__
+
+#endif

--- a/include/zephyr/xen/public/domctl.h
+++ b/include/zephyr/xen/public/domctl.h
@@ -18,9 +18,14 @@
 #include "xen.h"
 #include "event_channel.h"
 #include "grant_table.h"
+#include "hvm/save.h"
 #include "memory.h"
 
+#if __XEN_INTERFACE_VERSION__ >= 0x00040e00
+#define XEN_DOMCTL_INTERFACE_VERSION 0x00000016
+#else
 #define XEN_DOMCTL_INTERFACE_VERSION 0x00000015
+#endif
 
 /*
  * NB. xen_domctl.domain is an IN/OUT parameter for this operation.
@@ -150,15 +155,94 @@ struct xen_domctl_getdomaininfo {
 typedef struct xen_domctl_getdomaininfo xen_domctl_getdomaininfo_t;
 DEFINE_XEN_GUEST_HANDLE(xen_domctl_getdomaininfo_t);
 
+/* XEN_DOMCTL_getpageframeinfo */
+
+#define XEN_DOMCTL_PFINFO_LTAB_SHIFT 28
+#define XEN_DOMCTL_PFINFO_NOTAB   (0x0U<<28)
+#define XEN_DOMCTL_PFINFO_L1TAB   (0x1U<<28)
+#define XEN_DOMCTL_PFINFO_L2TAB   (0x2U<<28)
+#define XEN_DOMCTL_PFINFO_L3TAB   (0x3U<<28)
+#define XEN_DOMCTL_PFINFO_L4TAB   (0x4U<<28)
+#define XEN_DOMCTL_PFINFO_LTABTYPE_MASK (0x7U<<28)
+#define XEN_DOMCTL_PFINFO_LPINTAB (0x1U<<31)
+#define XEN_DOMCTL_PFINFO_XTAB    (0xfU<<28) /* invalid page */
+#define XEN_DOMCTL_PFINFO_XALLOC  (0xeU<<28) /* allocate-only page */
+#define XEN_DOMCTL_PFINFO_BROKEN  (0xdU<<28) /* broken page */
+#define XEN_DOMCTL_PFINFO_LTAB_MASK (0xfU<<28)
+
+/* XEN_DOMCTL_getpageframeinfo3 */
+/*
+ * Both value `num' and `array' may get modified by the hypercall to allow
+ * preemption.
+ */
+struct xen_domctl_getpageframeinfo3 {
+	/* IN variables. */
+	uint64_aligned_t num;
+	/* IN/OUT variables. */
+	XEN_GUEST_HANDLE_64(xen_pfn_t) array;
+};
 /*
  * Control shadow pagetables operation
  */
 /* XEN_DOMCTL_shadow_op */
 
-/* Memory allocation accessors. */
+/* Disable shadow mode. */
+#define XEN_DOMCTL_SHADOW_OP_OFF         0
+
+/* Enable shadow mode (mode contains ORed XEN_DOMCTL_SHADOW_ENABLE_* flags). */
+#define XEN_DOMCTL_SHADOW_OP_ENABLE      32
+
+/* Log-dirty bitmap operations. */
+ /* Return the bitmap and clean internal copy for next round. */
+#define XEN_DOMCTL_SHADOW_OP_CLEAN       11
+ /* Return the bitmap but do not modify internal copy. */
+#define XEN_DOMCTL_SHADOW_OP_PEEK        12
+
+/*
+ * Memory allocation accessors.  These APIs are broken and will be removed.
+ * Use XEN_DOMCTL_{get,set}_paging_mempool_size instead.
+ */
 #define XEN_DOMCTL_SHADOW_OP_GET_ALLOCATION	30
 #define XEN_DOMCTL_SHADOW_OP_SET_ALLOCATION	31
 
+/* Legacy enable operations. */
+ /* Equiv. to ENABLE with no mode flags. */
+#define XEN_DOMCTL_SHADOW_OP_ENABLE_TEST       1
+ /* Equiv. to ENABLE with mode flag ENABLE_LOG_DIRTY. */
+#define XEN_DOMCTL_SHADOW_OP_ENABLE_LOGDIRTY   2
+ /*
+  * No longer supported, was equiv. to ENABLE with mode flags
+  * ENABLE_REFCOUNT and ENABLE_TRANSLATE:
+#define XEN_DOMCTL_SHADOW_OP_ENABLE_TRANSLATE  3
+  */
+
+/* Mode flags for XEN_DOMCTL_SHADOW_OP_ENABLE. */
+ /*
+  * Shadow pagetables are refcounted: guest does not use explicit mmu
+  * operations nor write-protect its pagetables.
+  */
+#define XEN_DOMCTL_SHADOW_ENABLE_REFCOUNT  (1 << 1)
+ /*
+  * Log pages in a bitmap as they are dirtied.
+  * Used for live relocation to determine which pages must be re-sent.
+  */
+#define XEN_DOMCTL_SHADOW_ENABLE_LOG_DIRTY (1 << 2)
+ /*
+  * Automatically translate GPFNs into MFNs.
+  */
+#define XEN_DOMCTL_SHADOW_ENABLE_TRANSLATE (1 << 3)
+ /*
+  * Xen does not steal virtual address space from the guest.
+  * Requires HVM support.
+  */
+#define XEN_DOMCTL_SHADOW_ENABLE_EXTERNAL  (1 << 4)
+
+/* Mode flags for XEN_DOMCTL_SHADOW_OP_{CLEAN,PEEK}. */
+ /*
+  * This is the final iteration: Requesting to include pages mapped
+  * writably by the hypervisor in the dirty bitmap.
+  */
+#define XEN_DOMCTL_SHADOW_LOGDIRTY_FINAL   (1 << 0)
 struct xen_domctl_shadow_op_stats {
 	uint32_t fault_count;
 	uint32_t dirty_count;
@@ -207,7 +291,51 @@ struct xen_domctl_getvcpuinfo {
 	uint32_t cpu;                     /* current mapping   */
 };
 
-/*
+/* Get/set the NUMA node(s) with which the guest has affinity with. */
+/* XEN_DOMCTL_setnodeaffinity */
+/* XEN_DOMCTL_getnodeaffinity */
+struct xen_domctl_nodeaffinity {
+	struct xenctl_bitmap nodemap; /* IN */
+};
+
+
+/* Get/set which physical cpus a vcpu can execute on. */
+/* XEN_DOMCTL_setvcpuaffinity */
+/* XEN_DOMCTL_getvcpuaffinity */
+struct xen_domctl_vcpuaffinity {
+	/* IN variables. */
+	uint32_t  vcpu;
+/* Set/get the hard affinity for vcpu */
+#define _XEN_VCPUAFFINITY_HARD  0
+#define XEN_VCPUAFFINITY_HARD   (1U<<_XEN_VCPUAFFINITY_HARD)
+/* Set/get the soft affinity for vcpu */
+#define _XEN_VCPUAFFINITY_SOFT  1
+#define XEN_VCPUAFFINITY_SOFT   (1U<<_XEN_VCPUAFFINITY_SOFT)
+/* Undo SCHEDOP_pin_override */
+#define _XEN_VCPUAFFINITY_FORCE 2
+#define XEN_VCPUAFFINITY_FORCE  (1U<<_XEN_VCPUAFFINITY_FORCE)
+	uint32_t flags;
+	/**
+	 * IN/OUT variables.
+	 *
+	 * Both are IN/OUT for XEN_DOMCTL_setvcpuaffinity, in which case they
+	 * contain effective hard or/and soft affinity. That is, upon successful
+	 * return, cpumap_soft, contains the intersection of the soft affinity,
+	 * hard affinity and the cpupool's online CPUs for the domain (if
+	 * XEN_VCPUAFFINITY_SOFT was set in flags). cpumap_hard contains the
+	 * intersection between hard affinity and the cpupool's online CPUs (if
+	 * XEN_VCPUAFFINITY_HARD was set in flags).
+	 *
+	 * Both are OUT-only for XEN_DOMCTL_getvcpuaffinity, in which case they
+	 * contain the plain hard and/or soft affinity masks that were set during
+	 * previous successful calls to XEN_DOMCTL_setvcpuaffinity (or the
+	 * default values), without intersecting or altering them in any way.
+	 */
+	struct xenctl_bitmap cpumap_hard;
+	struct xenctl_bitmap cpumap_soft;
+};
+
+/**
  * XEN_DOMCTL_max_vcpus:
  *
  * The parameter passed to XEN_DOMCTL_max_vcpus must match the value passed to
@@ -293,17 +421,74 @@ struct xen_domctl_scheduler_op {
 	} u;
 };
 
+/* XEN_DOMCTL_setdomainhandle */
+struct xen_domctl_setdomainhandle {
+	xen_domain_handle_t handle;
+};
+
+
+/* XEN_DOMCTL_setdebugging */
+struct xen_domctl_setdebugging {
+	uint8_t enable;
+};
+
+
+/* XEN_DOMCTL_irq_permission */
+struct xen_domctl_irq_permission {
+	uint32_t pirq;
+	uint8_t allow_access;    /* flag to specify enable/disable of IRQ access */
+	uint8_t pad[3];
+};
 /* XEN_DOMCTL_iomem_permission */
 struct xen_domctl_iomem_permission {
 	uint64_aligned_t first_mfn;/* first page (physical page number) in range */
 	uint64_aligned_t nr_mfns;  /* number of pages in range (>0) */
 	uint8_t  allow_access;     /* allow (!0) or deny (0) access to range? */
 };
+/* XEN_DOMCTL_ioport_permission */
+struct xen_domctl_ioport_permission {
+	uint32_t first_port;              /* first port int range */
+	uint32_t nr_ports;                /* size of port range */
+	uint8_t  allow_access;            /* allow or deny access to range? */
+};
+
+
+/* XEN_DOMCTL_hypercall_init */
+struct xen_domctl_hypercall_init {
+	uint64_aligned_t  gmfn;           /* GMFN to be initialised */
+};
+
+
+/* XEN_DOMCTL_settimeoffset */
+struct xen_domctl_settimeoffset {
+	int64_aligned_t time_offset_seconds; /* applied to domain wallclock time */
+};
+
+/* XEN_DOMCTL_gethvmcontext */
+/* XEN_DOMCTL_sethvmcontext */
+struct xen_domctl_hvmcontext {
+	uint32_t size; /* IN/OUT: size of buffer / bytes filled */
+
+	XEN_GUEST_HANDLE_64(uint8) buffer; /* IN/OUT: data, or call
+					    * gethvmcontext with NULL
+					    * buffer to get size req'd
+					    */
+};
 
 /* XEN_DOMCTL_set_address_size */
 /* XEN_DOMCTL_get_address_size */
 struct xen_domctl_address_size {
 	uint32_t size;
+};
+/* XEN_DOMCTL_sendtrigger */
+#define XEN_DOMCTL_SENDTRIGGER_NMI    0
+#define XEN_DOMCTL_SENDTRIGGER_RESET  1
+#define XEN_DOMCTL_SENDTRIGGER_INIT   2
+#define XEN_DOMCTL_SENDTRIGGER_POWER  3
+#define XEN_DOMCTL_SENDTRIGGER_SLEEP  4
+struct xen_domctl_sendtrigger {
+	uint32_t  trigger;  /* IN */
+	uint32_t  vcpu;     /* IN */
 };
 
 /* Assign a device to a guest. Sets up IOMMU structures. */
@@ -340,6 +525,15 @@ struct xen_domctl_assign_device {
 	} u;
 };
 
+/* Retrieve sibling devices information of machine_sbdf */
+/* XEN_DOMCTL_get_device_group */
+struct xen_domctl_get_device_group {
+	uint32_t  machine_sbdf;     /* IN */
+	uint32_t  max_sdevs;        /* IN */
+	uint32_t  num_sdevs;        /* OUT */
+
+	XEN_GUEST_HANDLE_64(uint32)  sdev_array;   /* OUT */
+};
 /* Pass-through interrupts: bind real irq -> hvm devfn. */
 /* XEN_DOMCTL_bind_pt_irq */
 /* XEN_DOMCTL_unbind_pt_irq */
@@ -402,6 +596,327 @@ struct xen_domctl_memory_mapping {
 	uint32_t padding;           /* padding for 64-bit aligned structure */
 };
 
+/* Bind machine I/O port range -> HVM I/O port range. */
+/* XEN_DOMCTL_ioport_mapping */
+struct xen_domctl_ioport_mapping {
+	uint32_t first_gport;     /* first guest IO port*/
+	uint32_t first_mport;     /* first machine IO port */
+	uint32_t nr_ports;        /* size of port range */
+	uint32_t add_mapping;     /* add or remove mapping */
+};
+
+
+/*
+ * Pin caching type of RAM space for x86 HVM domU.
+ */
+/* XEN_DOMCTL_pin_mem_cacheattr */
+/* Caching types: these happen to be the same as x86 MTRR/PAT type codes. */
+#define XEN_DOMCTL_MEM_CACHEATTR_UC  0
+#define XEN_DOMCTL_MEM_CACHEATTR_WC  1
+#define XEN_DOMCTL_MEM_CACHEATTR_WT  4
+#define XEN_DOMCTL_MEM_CACHEATTR_WP  5
+#define XEN_DOMCTL_MEM_CACHEATTR_WB  6
+#define XEN_DOMCTL_MEM_CACHEATTR_UCM 7
+#define XEN_DOMCTL_DELETE_MEM_CACHEATTR (~(uint32_t)0)
+
+
+/* XEN_DOMCTL_set_ext_vcpucontext */
+/* XEN_DOMCTL_get_ext_vcpucontext */
+struct xen_domctl_ext_vcpucontext {
+	/* IN: VCPU that this call applies to. */
+	uint32_t         vcpu;
+	/*
+	 * SET: Size of struct (IN)
+	 * GET: Size of struct (OUT, up to 128 bytes)
+	 */
+	uint32_t         size;
+#if defined(CONFIG_X86) || defined(CONFIG_X86_64)
+	/* SYSCALL from 32-bit mode and SYSENTER callback information. */
+	/* NB. SYSCALL from 64-bit mode is contained in vcpu_guest_context_t */
+	uint64_aligned_t syscall32_callback_eip;
+	uint64_aligned_t sysenter_callback_eip;
+	uint16_t         syscall32_callback_cs;
+	uint16_t         sysenter_callback_cs;
+	uint8_t          syscall32_disables_events;
+	uint8_t          sysenter_disables_events;
+#if defined(__GNUC__)
+	union {
+		uint64_aligned_t mcg_cap;
+		struct hvm_vmce_vcpu vmce;
+	};
+#else
+	struct hvm_vmce_vcpu vmce;
+#endif
+#endif
+};
+
+/*
+ * Set the target domain for a domain
+ */
+/* XEN_DOMCTL_set_target */
+struct xen_domctl_set_target {
+	domid_t target;
+};
+
+#if defined(CONFIG_X86) || defined(CONFIG_X86_64)
+# define XEN_CPUID_INPUT_UNUSED  0xFFFFFFFF
+
+/*
+ * XEN_DOMCTL_{get,set}_cpu_policy (x86 specific)
+ *
+ * Query or set the CPUID and MSR policies for a specific domain.
+ */
+struct xen_domctl_cpu_policy {
+	uint32_t nr_leaves; /* IN/OUT: Number of leaves in/written to 'leaves' */
+	uint32_t nr_msrs;   /* IN/OUT: Number of MSRs in/written to 'msrs' */
+
+	XEN_GUEST_HANDLE_64(xen_cpuid_leaf_t) leaves; /* IN/OUT */
+
+	XEN_GUEST_HANDLE_64(xen_msr_entry_t)  msrs;   /* IN/OUT */
+
+	/*
+	 * OUT, set_policy only.  Written in some (but not all) error cases to
+	 * identify the CPUID leaf/subleaf and/or MSR which auditing objects to.
+	 */
+	uint32_t err_leaf, err_subleaf, err_msr;
+};
+typedef struct xen_domctl_cpu_policy xen_domctl_cpu_policy_t;
+DEFINE_XEN_GUEST_HANDLE(xen_domctl_cpu_policy_t);
+#endif
+
+/*
+ * Arranges that if the domain suspends (specifically, if it shuts
+ * down with code SHUTDOWN_suspend), this event channel will be
+ * notified.
+ *
+ * This is _instead of_ the usual notification to the global
+ * VIRQ_DOM_EXC.  (In most systems that pirq is owned by xenstored.)
+ *
+ * Only one subscription per domain is possible.  Last subscriber
+ * wins; others are silently displaced.
+ *
+ * NB that contrary to the rather general name, it only applies to
+ * domain shutdown with code suspend.  Shutdown for other reasons
+ * (including crash), and domain death, are notified to VIRQ_DOM_EXC
+ * regardless.
+ */
+/* XEN_DOMCTL_subscribe */
+struct xen_domctl_subscribe {
+	uint32_t port; /* IN */
+};
+
+/* XEN_DOMCTL_debug_op */
+#define XEN_DOMCTL_DEBUG_OP_SINGLE_STEP_OFF         0
+#define XEN_DOMCTL_DEBUG_OP_SINGLE_STEP_ON          1
+struct xen_domctl_debug_op {
+	uint32_t op;   /* IN */
+	uint32_t vcpu; /* IN */
+};
+
+/*
+ * Request a particular record from the HVM context
+ */
+/* XEN_DOMCTL_gethvmcontext_partial */
+struct xen_domctl_hvmcontext_partial {
+	uint32_t type;                      /* IN: Type of record required */
+	uint32_t instance;                  /* IN: Instance of that type */
+	uint64_aligned_t bufsz;             /* IN: size of buffer */
+
+	XEN_GUEST_HANDLE_64(uint8) buffer;  /* OUT: buffer to write record into */
+};
+
+
+/* XEN_DOMCTL_gettscinfo */
+/* XEN_DOMCTL_settscinfo */
+struct xen_domctl_tsc_info {
+	/* IN/OUT */
+	uint32_t tsc_mode;
+	uint32_t gtsc_khz;
+	uint32_t incarnation;
+	uint32_t pad;
+	uint64_aligned_t elapsed_nsec;
+};
+
+/* XEN_DOMCTL_gdbsx_guestmemio      guest mem io */
+struct xen_domctl_gdbsx_memio {
+	/* IN */
+	uint64_aligned_t pgd3val;/* optional: init_mm.pgd[3] value */
+	uint64_aligned_t gva;    /* guest virtual address */
+	uint64_aligned_t uva;    /* user buffer virtual address */
+	uint32_t         len;    /* number of bytes to read/write */
+	uint8_t          gwr;    /* 0 = read from guest. 1 = write to guest */
+	/* OUT */
+	uint32_t         remain; /* bytes remaining to be copied */
+};
+
+/* XEN_DOMCTL_gdbsx_pausevcpu */
+/* XEN_DOMCTL_gdbsx_unpausevcpu */
+struct xen_domctl_gdbsx_pauseunp_vcpu { /* pause/unpause a vcpu */
+	uint32_t         vcpu;         /* which vcpu */
+};
+
+/* XEN_DOMCTL_gdbsx_domstatus */
+struct xen_domctl_gdbsx_domstatus {
+	/* OUT */
+	uint8_t          paused;     /* is the domain paused */
+	uint32_t         vcpu_id;    /* any vcpu in an event? */
+	uint32_t         vcpu_ev;    /* if yes, what event? */
+};
+
+/*
+ * VM event operations
+ */
+
+/* XEN_DOMCTL_vm_event_op */
+
+/*
+ * There are currently three rings available for VM events:
+ * sharing, monitor and paging. This hypercall allows one to
+ * control these rings (enable/disable), as well as to signal
+ * to the hypervisor to pull responses (resume) from the given
+ * ring.
+ */
+#define XEN_VM_EVENT_ENABLE               0
+#define XEN_VM_EVENT_DISABLE              1
+#define XEN_VM_EVENT_RESUME               2
+#define XEN_VM_EVENT_GET_VERSION          3
+
+/*
+ * Domain memory paging
+ * Page memory in and out.
+ * Domctl interface to set up and tear down the
+ * pager<->hypervisor interface. Use XENMEM_paging_op*
+ * to perform per-page operations.
+ *
+ * The XEN_VM_EVENT_PAGING_ENABLE domctl returns several
+ * non-standard error codes to indicate why paging could not be enabled:
+ * ENODEV - host lacks HAP support (EPT/NPT) or HAP is disabled in guest
+ * EMLINK - guest has iommu passthrough enabled
+ * EXDEV  - guest has PoD enabled
+ * EBUSY  - guest has or had paging enabled, ring buffer still active
+ */
+#define XEN_DOMCTL_VM_EVENT_OP_PAGING            1
+
+/*
+ * Monitor helper.
+ *
+ * As with paging, use the domctl for teardown/setup of the
+ * helper<->hypervisor interface.
+ *
+ * The monitor interface can be used to register for various VM events. For
+ * example, there are HVM hypercalls to set the per-page access permissions
+ * of every page in a domain.  When one of these permissions--independent,
+ * read, write, and execute--is violated, the VCPU is paused and a memory event
+ * is sent with what happened. The memory event handler can then resume the
+ * VCPU and redo the access with a XEN_VM_EVENT_RESUME option.
+ *
+ * See public/vm_event.h for the list of available events that can be
+ * subscribed to via the monitor interface.
+ *
+ * The XEN_VM_EVENT_MONITOR_* domctls returns
+ * non-standard error codes to indicate why access could not be enabled:
+ * ENODEV - host lacks HAP support (EPT/NPT) or HAP is disabled in guest
+ * EBUSY  - guest has or had access enabled, ring buffer still active
+ *
+ */
+#define XEN_DOMCTL_VM_EVENT_OP_MONITOR           2
+
+/*
+ * Sharing ENOMEM helper.
+ *
+ * As with paging, use the domctl for teardown/setup of the
+ * helper<->hypervisor interface.
+ *
+ * If setup, this ring is used to communicate failed allocations
+ * in the unshare path. XENMEM_sharing_op_resume is used to wake up
+ * vcpus that could not unshare.
+ *
+ * Note that sharing can be turned on (as per the domctl below)
+ * *without* this ring being setup.
+ */
+#define XEN_DOMCTL_VM_EVENT_OP_SHARING           3
+
+/*
+ * Use for teardown/setup of helper<->hypervisor interface for paging,
+ * access and sharing.
+ */
+struct xen_domctl_vm_event_op {
+	uint32_t       op;           /* XEN_VM_EVENT_* */
+	uint32_t       mode;         /* XEN_DOMCTL_VM_EVENT_OP_* */
+
+	union {
+		struct {
+			uint32_t port;       /* OUT: event channel for ring */
+		} enable;
+
+		uint32_t version;
+	} u;
+};
+
+/*
+ * Memory sharing operations
+ */
+/*
+ * XEN_DOMCTL_mem_sharing_op.
+ * The CONTROL sub-domctl is used for bringup/teardown.
+ */
+#define XEN_DOMCTL_MEM_SHARING_CONTROL          0
+
+struct xen_domctl_mem_sharing_op {
+	uint8_t op; /* XEN_DOMCTL_MEM_SHARING_* */
+
+	union {
+		uint8_t enable;                   /* CONTROL */
+	} u;
+};
+
+struct xen_domctl_audit_p2m {
+	/* OUT error counts */
+	uint64_t orphans;
+	uint64_t m2p_bad;
+	uint64_t p2m_bad;
+};
+
+struct xen_domctl_set_virq_handler {
+	uint32_t virq; /* IN */
+};
+
+#if defined(CONFIG_X86) || defined(CONFIG_x86_64)
+/* XEN_DOMCTL_setvcpuextstate */
+/* XEN_DOMCTL_getvcpuextstate */
+struct xen_domctl_vcpuextstate {
+	/* IN: VCPU that this call applies to. */
+	uint32_t         vcpu;
+	/*
+	 * SET: Ignored.
+	 * GET: xfeature support mask of struct (IN/OUT)
+	 * xfeature mask is served as identifications of the saving format
+	 * so that compatible CPUs can have a check on format to decide
+	 * whether it can restore.
+	 */
+	uint64_aligned_t         xfeature_mask;
+	/*
+	 * SET: Size of struct (IN)
+	 * GET: Size of struct (IN/OUT)
+	 */
+	uint64_aligned_t         size;
+
+	XEN_GUEST_HANDLE_64(uint64) buffer;
+};
+#endif
+
+/*
+ * XEN_DOMCTL_set_access_required: sets whether a memory event listener
+ * must be present to handle page access events: if false, the page
+ * access will revert to full permissions if no one is listening;
+ */
+struct xen_domctl_set_access_required {
+	uint8_t access_required;
+};
+
+struct xen_domctl_set_broken_page_p2m {
+	uint64_aligned_t pfn;
+};
 /*
  * ARM: Clean and invalidate caches associated with given region of
  * guest memory.
@@ -427,6 +942,251 @@ struct xen_domctl_paging_mempool {
 	uint64_aligned_t size; /* Size in bytes. */
 };
 
+#if defined(CONFIG_X86) || defined(CONFIG_X86_64)
+struct xen_domctl_vcpu_msr {
+	uint32_t         index;
+	uint32_t         reserved;
+	uint64_aligned_t value;
+};
+typedef struct xen_domctl_vcpu_msr xen_domctl_vcpu_msr_t;
+DEFINE_XEN_GUEST_HANDLE(xen_domctl_vcpu_msr_t);
+
+/*
+ * XEN_DOMCTL_set_vcpu_msrs / XEN_DOMCTL_get_vcpu_msrs.
+ *
+ * Input:
+ * - A NULL 'msrs' guest handle is a request for the maximum 'msr_count'.
+ * - Otherwise, 'msr_count' is the number of entries in 'msrs'.
+ *
+ * Output for get:
+ * - If 'msr_count' is less than the number Xen needs to write, -ENOBUFS shall
+ *   be returned and 'msr_count' updated to reflect the intended number.
+ * - On success, 'msr_count' shall indicate the number of MSRs written, which
+ *   may be less than the maximum if some are not currently used by the vcpu.
+ *
+ * Output for set:
+ * - If Xen encounters an error with a specific MSR, -EINVAL shall be returned
+ *   and 'msr_count' shall be set to the offending index, to aid debugging.
+ */
+struct xen_domctl_vcpu_msrs {
+	uint32_t vcpu;                                   /* IN     */
+	uint32_t msr_count;                              /* IN/OUT */
+
+	XEN_GUEST_HANDLE_64(xen_domctl_vcpu_msr_t) msrs; /* IN/OUT */
+};
+#endif
+
+/* XEN_DOMCTL_setvnumainfo: specifies a virtual NUMA topology for the guest */
+struct xen_domctl_vnuma {
+	/* IN: number of vNUMA nodes to setup. Shall be greater than 0 */
+	uint32_t nr_vnodes;
+	/* IN: number of memory ranges to setup */
+	uint32_t nr_vmemranges;
+	/*
+	 * IN: number of vCPUs of the domain (used as size of the vcpu_to_vnode
+	 * array declared below). Shall be equal to the domain's max_vcpus.
+	 */
+	uint32_t nr_vcpus;
+	uint32_t pad;                                  /* must be zero */
+
+	/*
+	 * IN: array for specifying the distances of the vNUMA nodes
+	 * between each others. Shall have nr_vnodes*nr_vnodes elements.
+	 */
+	XEN_GUEST_HANDLE_64(uint) vdistance;
+	/*
+	 * IN: array for specifying to what vNUMA node each vCPU belongs.
+	 * Shall have nr_vcpus elements.
+	 */
+	XEN_GUEST_HANDLE_64(uint) vcpu_to_vnode;
+	/*
+	 * IN: array for specifying on what physical NUMA node each vNUMA
+	 * node is placed. Shall have nr_vnodes elements.
+	 */
+	XEN_GUEST_HANDLE_64(uint) vnode_to_pnode;
+	/*
+	 * IN: array for specifying the memory ranges. Shall have
+	 * nr_vmemranges elements.
+	 */
+	XEN_GUEST_HANDLE_64(xen_vmemrange_t) vmemrange;
+};
+
+struct xen_domctl_psr_cmt_op {
+#define XEN_DOMCTL_PSR_CMT_OP_DETACH         0
+#define XEN_DOMCTL_PSR_CMT_OP_ATTACH         1
+#define XEN_DOMCTL_PSR_CMT_OP_QUERY_RMID     2
+	uint32_t cmd;
+	uint32_t data;
+};
+
+/*  XEN_DOMCTL_MONITOR_*
+ *
+ * Enable/disable monitoring various VM events.
+ * This domctl configures what events will be reported to helper apps
+ * via the ring buffer "MONITOR". The ring has to be first enabled
+ * with the domctl XEN_DOMCTL_VM_EVENT_OP_MONITOR.
+ *
+ * GET_CAPABILITIES can be used to determine which of these features is
+ * available on a given platform.
+ *
+ * NOTICE: mem_access events are also delivered via the "MONITOR" ring buffer;
+ * however, enabling/disabling those events is performed with the use of
+ * memory_op hypercalls!
+ */
+#define XEN_DOMCTL_MONITOR_OP_ENABLE            0
+#define XEN_DOMCTL_MONITOR_OP_DISABLE           1
+#define XEN_DOMCTL_MONITOR_OP_GET_CAPABILITIES  2
+#define XEN_DOMCTL_MONITOR_OP_EMULATE_EACH_REP  3
+/*
+ * Control register feature can result in guest-crashes when the monitor
+ * subsystem is being turned off. User has to take special precautions
+ * to ensure all vCPUs have resumed before it is safe to turn it off.
+ */
+#define XEN_DOMCTL_MONITOR_OP_CONTROL_REGISTERS 4
+
+#define XEN_DOMCTL_MONITOR_EVENT_WRITE_CTRLREG         0
+#define XEN_DOMCTL_MONITOR_EVENT_MOV_TO_MSR            1
+#define XEN_DOMCTL_MONITOR_EVENT_SINGLESTEP            2
+#define XEN_DOMCTL_MONITOR_EVENT_SOFTWARE_BREAKPOINT   3
+#define XEN_DOMCTL_MONITOR_EVENT_GUEST_REQUEST         4
+#define XEN_DOMCTL_MONITOR_EVENT_DEBUG_EXCEPTION       5
+#define XEN_DOMCTL_MONITOR_EVENT_CPUID                 6
+#define XEN_DOMCTL_MONITOR_EVENT_PRIVILEGED_CALL       7
+#define XEN_DOMCTL_MONITOR_EVENT_INTERRUPT             8
+#define XEN_DOMCTL_MONITOR_EVENT_DESC_ACCESS           9
+#define XEN_DOMCTL_MONITOR_EVENT_EMUL_UNIMPLEMENTED    10
+/* Enabled by default */
+#define XEN_DOMCTL_MONITOR_EVENT_INGUEST_PAGEFAULT     11
+#define XEN_DOMCTL_MONITOR_EVENT_VMEXIT                12
+#define XEN_DOMCTL_MONITOR_EVENT_IO                    13
+
+struct xen_domctl_monitor_op {
+	uint32_t op; /* XEN_DOMCTL_MONITOR_OP_* */
+
+	/*
+	 * When used with ENABLE/DISABLE this has to be set to
+	 * the requested XEN_DOMCTL_MONITOR_EVENT_* value.
+	 * With GET_CAPABILITIES this field returns a bitmap of
+	 * events supported by the platform, in the format
+	 * (1 << XEN_DOMCTL_MONITOR_EVENT_*).
+	 */
+	uint32_t event;
+
+	/*
+	 * Further options when issuing XEN_DOMCTL_MONITOR_OP_ENABLE.
+	 */
+	union {
+		struct {
+			/* Which control register */
+			uint8_t index;
+			/* Pause vCPU until response */
+			uint8_t sync;
+			/* Send event only on a change of value */
+			uint8_t onchangeonly;
+			/* Allignment padding */
+			uint8_t pad1;
+			uint32_t pad2;
+			/*
+			 * Send event only if the changed bit in the control register
+			 * is not masked.
+			 */
+			uint64_aligned_t bitmask;
+		} mov_to_cr;
+
+		struct {
+			uint32_t msr;
+			/* Send event only on a change of value */
+			uint8_t onchangeonly;
+		} mov_to_msr;
+
+		struct {
+			/* Pause vCPU until response */
+			uint8_t sync;
+			uint8_t allow_userspace;
+		} guest_request;
+
+		struct {
+			/* Pause vCPU until response */
+			uint8_t sync;
+		} debug_exception;
+
+		struct {
+			/* Send event and don't process vmexit */
+			uint8_t sync;
+		} vmexit;
+	} u;
+};
+
+struct xen_domctl_psr_alloc {
+#define XEN_DOMCTL_PSR_SET_L3_CBM     0
+#define XEN_DOMCTL_PSR_GET_L3_CBM     1
+#define XEN_DOMCTL_PSR_SET_L3_CODE    2
+#define XEN_DOMCTL_PSR_SET_L3_DATA    3
+#define XEN_DOMCTL_PSR_GET_L3_CODE    4
+#define XEN_DOMCTL_PSR_GET_L3_DATA    5
+#define XEN_DOMCTL_PSR_SET_L2_CBM     6
+#define XEN_DOMCTL_PSR_GET_L2_CBM     7
+#define XEN_DOMCTL_PSR_SET_MBA_THRTL  8
+#define XEN_DOMCTL_PSR_GET_MBA_THRTL  9
+	uint32_t cmd;       /* IN: XEN_DOMCTL_PSR_* */
+	uint32_t target;    /* IN */
+	uint64_t data;      /* IN/OUT */
+};
+
+/* XEN_DOMCTL_vuart_op */
+struct xen_domctl_vuart_op {
+#define XEN_DOMCTL_VUART_OP_INIT  0
+	uint32_t cmd;           /* XEN_DOMCTL_VUART_OP_* */
+#define XEN_DOMCTL_VUART_TYPE_VPL011 0
+	uint32_t type;          /* IN - type of vuart.
+				 *      Currently only vpl011 supported.
+				 */
+	uint64_aligned_t  gfn;  /* IN - guest gfn to be used as a
+				 *      ring buffer.
+				 */
+	domid_t console_domid;  /* IN - domid of domain running the
+				 *      backend console.
+				 */
+	uint8_t pad[2];
+	evtchn_port_t evtchn;   /* OUT - remote port of the event
+				 *       channel used for sending
+				 *       ring buffer events.
+				 */
+};
+
+/* XEN_DOMCTL_vmtrace_op: Perform VM tracing operations. */
+struct xen_domctl_vmtrace_op {
+	uint32_t cmd;           /* IN */
+	uint32_t vcpu;          /* IN */
+	uint64_aligned_t key;   /* IN     - @cmd specific data. */
+	uint64_aligned_t value; /* IN/OUT - @cmd specific data. */
+
+/*
+ * General enable/disable of tracing.
+ *
+ * XEN_DOMCTL_vmtrace_reset_and_enable is provided as optimisation for
+ * common usecases, which want to reset status and position information
+ * when turning tracing back on.
+ */
+#define XEN_DOMCTL_vmtrace_enable             1
+#define XEN_DOMCTL_vmtrace_disable            2
+#define XEN_DOMCTL_vmtrace_reset_and_enable   3
+
+/* Obtain the current output position within the buffer.  Fills @value. */
+#define XEN_DOMCTL_vmtrace_output_position    4
+
+/*
+ * Get/Set platform specific configuration.
+ *
+ * For Intel Processor Trace, @key/@value are interpreted as MSR
+ * reads/writes to MSR_RTIT_*, filtered to a safe subset.
+ */
+#define XEN_DOMCTL_vmtrace_get_option         5
+#define XEN_DOMCTL_vmtrace_set_option         6
+};
+typedef struct xen_domctl_vmtrace_op xen_domctl_vmtrace_op_t;
+DEFINE_XEN_GUEST_HANDLE(xen_domctl_vmtrace_op_t);
+
 struct xen_domctl {
 	uint32_t cmd;
 #define XEN_DOMCTL_createdomain			1
@@ -448,6 +1208,10 @@ struct xen_domctl {
 #define XEN_DOMCTL_iomem_permission		20
 #define XEN_DOMCTL_ioport_permission		21
 #define XEN_DOMCTL_hypercall_init		22
+#ifdef CONFIG_XEN_INITIAL_DOMAIN
+/* #define XEN_DOMCTL_arch_setup                 23 Obsolete IA64 only */
+#define XEN_DOMCTL_soft_reset_cont               23
+#endif
 #define XEN_DOMCTL_settimeoffset		24
 #define XEN_DOMCTL_getvcpuaffinity		25
 #define XEN_DOMCTL_real_mode_area		26 /* Obsolete PPC only */
@@ -509,17 +1273,57 @@ struct xen_domctl {
 	union {
 		struct xen_domctl_createdomain createdomain;
 		struct xen_domctl_getdomaininfo getdomaininfo;
+		struct xen_domctl_getpageframeinfo3 getpageframeinfo3;
+		struct xen_domctl_nodeaffinity      nodeaffinity;
+		struct xen_domctl_vcpuaffinity      vcpuaffinity;
+		struct xen_domctl_shadow_op         shadow_op;
 		struct xen_domctl_max_mem max_mem;
 		struct xen_domctl_vcpucontext vcpucontext;
 		struct xen_domctl_getvcpuinfo getvcpuinfo;
 		struct xen_domctl_max_vcpus max_vcpus;
 		struct xen_domctl_scheduler_op scheduler_op;
+		struct xen_domctl_setdomainhandle   setdomainhandle;
+		struct xen_domctl_setdebugging      setdebugging;
+		struct xen_domctl_irq_permission    irq_permission;
 		struct xen_domctl_iomem_permission iomem_permission;
+		struct xen_domctl_ioport_permission ioport_permission;
+		struct xen_domctl_hypercall_init    hypercall_init;
+		struct xen_domctl_settimeoffset     settimeoffset;
+		struct xen_domctl_tsc_info          tsc_info;
+		struct xen_domctl_hvmcontext        hvmcontext;
+		struct xen_domctl_hvmcontext_partial hvmcontext_partial;
 		struct xen_domctl_address_size address_size;
+		struct xen_domctl_sendtrigger       sendtrigger;
+		struct xen_domctl_get_device_group  get_device_group;
 		struct xen_domctl_assign_device assign_device;
 		struct xen_domctl_bind_pt_irq bind_pt_irq;
 		struct xen_domctl_memory_mapping memory_mapping;
+		struct xen_domctl_ioport_mapping    ioport_mapping;
+		struct xen_domctl_ext_vcpucontext   ext_vcpucontext;
+		struct xen_domctl_set_target        set_target;
+		struct xen_domctl_subscribe         subscribe;
+		struct xen_domctl_debug_op          debug_op;
+		struct xen_domctl_vm_event_op       vm_event_op;
+		struct xen_domctl_mem_sharing_op    mem_sharing_op;
+#if defined(CONFIG_X86) || defined(CONFIG_X86_64)
+		struct xen_domctl_cpu_policy        cpu_policy;
+		struct xen_domctl_vcpuextstate      vcpuextstate;
+		struct xen_domctl_vcpu_msrs         vcpu_msrs;
+#endif
+		struct xen_domctl_set_access_required access_required;
+		struct xen_domctl_audit_p2m         audit_p2m;
+		struct xen_domctl_set_virq_handler  set_virq_handler;
+		struct xen_domctl_gdbsx_memio       gdbsx_guest_memio;
+		struct xen_domctl_set_broken_page_p2m set_broken_page_p2m;
 		struct xen_domctl_cacheflush cacheflush;
+		struct xen_domctl_gdbsx_pauseunp_vcpu gdbsx_pauseunp_vcpu;
+		struct xen_domctl_gdbsx_domstatus   gdbsx_domstatus;
+		struct xen_domctl_vnuma             vnuma;
+		struct xen_domctl_psr_cmt_op        psr_cmt_op;
+		struct xen_domctl_monitor_op        monitor_op;
+		struct xen_domctl_psr_alloc         psr_alloc;
+		struct xen_domctl_vuart_op          vuart_op;
+		struct xen_domctl_vmtrace_op        vmtrace_op;
 		struct xen_domctl_paging_mempool paging_mempool;
 		uint8_t pad[128];
 	} u;

--- a/include/zephyr/xen/public/event_channel.h
+++ b/include/zephyr/xen/public/event_channel.h
@@ -120,6 +120,56 @@ struct evtchn_bind_interdomain {
 typedef struct evtchn_bind_interdomain evtchn_bind_interdomain_t;
 
 /*
+ * EVTCHNOP_bind_virq: Bind a local event channel to VIRQ <irq> on specified
+ * vcpu.
+ * NOTES:
+ *  1. Virtual IRQs are classified as per-vcpu or global. See the VIRQ list
+ *     in xen.h for the classification of each VIRQ.
+ *  2. Global VIRQs must be allocated on VCPU0 but can subsequently be
+ *     re-bound via EVTCHNOP_bind_vcpu.
+ *  3. Per-vcpu VIRQs may be bound to at most one event channel per vcpu.
+ *     The allocated event channel is bound to the specified vcpu and the
+ *     binding cannot be changed.
+ */
+struct evtchn_bind_virq {
+	/* IN parameters. */
+	uint32_t virq; /* enum virq */
+	uint32_t vcpu;
+	/* OUT parameters. */
+	evtchn_port_t port;
+};
+typedef struct evtchn_bind_virq evtchn_bind_virq_t;
+
+/*
+ * EVTCHNOP_bind_pirq: Bind a local event channel to a real IRQ (PIRQ <irq>).
+ * NOTES:
+ *  1. A physical IRQ may be bound to at most one event channel per domain.
+ *  2. Only a sufficiently-privileged domain may bind to a physical IRQ.
+ */
+struct evtchn_bind_pirq {
+	/* IN parameters. */
+	uint32_t pirq;
+#define BIND_PIRQ__WILL_SHARE 1
+	uint32_t flags; /* BIND_PIRQ__* */
+	/* OUT parameters. */
+	evtchn_port_t port;
+};
+typedef struct evtchn_bind_pirq evtchn_bind_pirq_t;
+
+/*
+ * EVTCHNOP_bind_ipi: Bind a local event channel to receive events.
+ * NOTES:
+ *  1. The allocated event channel is bound to the specified vcpu. The binding
+ *     may not be changed.
+ */
+struct evtchn_bind_ipi {
+	uint32_t vcpu;
+	/* OUT parameters. */
+	evtchn_port_t port;
+};
+typedef struct evtchn_bind_ipi evtchn_bind_ipi_t;
+
+/*
  * EVTCHNOP_close: Close a local event channel <port>. If the channel is
  * interdomain then the remote end is placed in the unbound state
  * (EVTCHNSTAT_unbound), awaiting a new connection.
@@ -176,6 +226,25 @@ struct evtchn_status {
 typedef struct evtchn_status evtchn_status_t;
 
 /*
+ * EVTCHNOP_bind_vcpu: Specify which vcpu a channel should notify when an
+ * event is pending.
+ * NOTES:
+ *  1. IPI-bound channels always notify the vcpu specified at bind time.
+ *     This binding cannot be changed.
+ *  2. Per-VCPU VIRQ channels always notify the vcpu specified at bind time.
+ *     This binding cannot be changed.
+ *  3. All other channels notify vcpu0 by default. This default is set when
+ *     the channel is allocated (a port that is freed and subsequently reused
+ *     has its binding reset to vcpu0).
+ */
+struct evtchn_bind_vcpu {
+	/* IN parameters. */
+	evtchn_port_t port;
+	uint32_t vcpu;
+};
+typedef struct evtchn_bind_vcpu evtchn_bind_vcpu_t;
+
+/*
  * EVTCHNOP_unmask: Unmask the specified local event-channel port and deliver
  * a notification to the appropriate VCPU if an event is pending.
  */
@@ -202,6 +271,33 @@ struct evtchn_reset {
 typedef struct evtchn_reset evtchn_reset_t;
 
 /*
+ * EVTCHNOP_init_control: initialize the control block for the FIFO ABI.
+ *
+ * Note: any events that are currently pending will not be resent and
+ * will be lost.  Guests should call this before binding any event to
+ * avoid losing any events.
+ */
+struct evtchn_init_control {
+	/* IN parameters. */
+	uint64_t control_gfn;
+	uint32_t offset;
+	uint32_t vcpu;
+	/* OUT parameters. */
+	uint8_t link_bits;
+	uint8_t _pad[7];
+};
+typedef struct evtchn_init_control evtchn_init_control_t;
+
+/*
+ * EVTCHNOP_expand_array: add an additional page to the event array.
+ */
+struct evtchn_expand_array {
+	/* IN parameters. */
+	uint64_t array_gfn;
+};
+typedef struct evtchn_expand_array evtchn_expand_array_t;
+
+/*
  * EVTCHNOP_set_priority: set the priority for an event channel.
  */
 struct evtchn_set_priority {
@@ -211,6 +307,62 @@ struct evtchn_set_priority {
 };
 typedef struct evtchn_set_priority evtchn_set_priority_t;
 
+/*
+ * ` enum neg_errnoval
+ * ` HYPERVISOR_event_channel_op_compat(struct evtchn_op *op)
+ * `
+ * Superceded by new event_channel_op() hypercall since 0x00030202.
+ */
+struct evtchn_op {
+	uint32_t cmd; /* enum event_channel_op */
+	union {
+		evtchn_alloc_unbound_t    alloc_unbound;
+		evtchn_bind_interdomain_t bind_interdomain;
+		evtchn_bind_virq_t        bind_virq;
+		evtchn_bind_pirq_t        bind_pirq;
+		evtchn_bind_ipi_t         bind_ipi;
+		evtchn_close_t            close;
+		evtchn_send_t             send;
+		evtchn_status_t           status;
+		evtchn_bind_vcpu_t        bind_vcpu;
+		evtchn_unmask_t           unmask;
+	} u;
+};
+typedef struct evtchn_op evtchn_op_t;
+DEFINE_XEN_GUEST_HANDLE(evtchn_op_t);
+
+/*
+ * 2-level ABI
+ */
 #define EVTCHN_2L_NR_CHANNELS (sizeof(xen_ulong_t) * sizeof(xen_ulong_t) * 64)
+/*
+ * FIFO ABI
+ */
+
+/* Events may have priorities from 0 (highest) to 15 (lowest). */
+#define EVTCHN_FIFO_PRIORITY_MAX     0
+#define EVTCHN_FIFO_PRIORITY_DEFAULT 7
+#define EVTCHN_FIFO_PRIORITY_MIN     15
+
+#define EVTCHN_FIFO_MAX_QUEUES (EVTCHN_FIFO_PRIORITY_MIN + 1)
+
+typedef uint32_t event_word_t;
+
+#define EVTCHN_FIFO_PENDING 31
+#define EVTCHN_FIFO_MASKED  30
+#define EVTCHN_FIFO_LINKED  29
+#define EVTCHN_FIFO_BUSY    28
+
+#define EVTCHN_FIFO_LINK_BITS 17
+#define EVTCHN_FIFO_LINK_MASK ((1 << EVTCHN_FIFO_LINK_BITS) - 1)
+
+#define EVTCHN_FIFO_NR_CHANNELS (1 << EVTCHN_FIFO_LINK_BITS)
+
+struct evtchn_fifo_control_block {
+	uint32_t ready;
+	uint32_t _rsvd;
+	uint32_t head[EVTCHN_FIFO_MAX_QUEUES];
+};
+typedef struct evtchn_fifo_control_block evtchn_fifo_control_block_t;
 
 #endif /* __XEN_PUBLIC_EVENT_CHANNEL_H__ */

--- a/include/zephyr/xen/public/features.h
+++ b/include/zephyr/xen/public/features.h
@@ -1,0 +1,126 @@
+/* SPDX-License-Identifier: MIT */
+
+/******************************************************************************
+ * features.h
+ *
+ * Feature flags, reported by XENVER_get_features.
+ *
+ * Copyright (c) 2006, Keir Fraser <keir@xensource.com>
+ */
+
+#ifndef __XEN_PUBLIC_FEATURES_H__
+#define __XEN_PUBLIC_FEATURES_H__
+
+/*
+ * `incontents 200 elfnotes_features XEN_ELFNOTE_FEATURES
+ *
+ * The list of all the features the guest supports. They are set by
+ * parsing the XEN_ELFNOTE_FEATURES and XEN_ELFNOTE_SUPPORTED_FEATURES
+ * string. The format is the  feature names (as given here without the
+ * "XENFEAT_" prefix) separated by '|' characters.
+ * If a feature is required for the kernel to function then the feature name
+ * must be preceded by a '!' character.
+ *
+ * Note that if XEN_ELFNOTE_SUPPORTED_FEATURES is used, then in the
+ * XENFEAT_dom0 MUST be set if the guest is to be booted as dom0,
+ */
+
+/*
+ * If set, the guest does not need to write-protect its pagetables, and can
+ * update them via direct writes.
+ */
+#define XENFEAT_writable_page_tables       0
+
+/*
+ * If set, the guest does not need to write-protect its segment descriptor
+ * tables, and can update them via direct writes.
+ */
+#define XENFEAT_writable_descriptor_tables 1
+
+/*
+ * If set, translation between the guest's 'pseudo-physical' address space
+ * and the host's machine address space are handled by the hypervisor. In this
+ * mode the guest does not need to perform phys-to/from-machine translations
+ * when performing page table operations.
+ */
+#define XENFEAT_auto_translated_physmap    2
+
+/* If set, the guest is running in supervisor mode (e.g., x86 ring 0). */
+#define XENFEAT_supervisor_mode_kernel     3
+
+/*
+ * If set, the guest does not need to allocate x86 PAE page directories
+ * below 4GB. This flag is usually implied by auto_translated_physmap.
+ */
+#define XENFEAT_pae_pgdir_above_4gb        4
+
+/* x86: Does this Xen host support the MMU_PT_UPDATE_PRESERVE_AD hypercall? */
+#define XENFEAT_mmu_pt_update_preserve_ad  5
+
+/* x86: Does this Xen host support the MMU_{CLEAR,COPY}_PAGE hypercall? */
+#define XENFEAT_highmem_assist             6
+
+/*
+ * If set, GNTTABOP_map_grant_ref honors flags to be placed into guest kernel
+ * available pte bits.
+ */
+#define XENFEAT_gnttab_map_avail_bits      7
+
+/* x86: Does this Xen host support the HVM callback vector type? */
+#define XENFEAT_hvm_callback_vector        8
+
+/* x86: pvclock algorithm is safe to use on HVM */
+#define XENFEAT_hvm_safe_pvclock           9
+
+/* x86: pirq can be used by HVM guests */
+#define XENFEAT_hvm_pirqs                 10
+
+/* operation as Dom0 is supported */
+#define XENFEAT_dom0                      11
+
+/* Xen also maps grant references at pfn = mfn.
+ * This feature flag is deprecated and should not be used.
+#define XENFEAT_grant_map_identity        12
+ */
+
+/* Guest can use XENMEMF_vnode to specify virtual node for memory op. */
+#define XENFEAT_memory_op_vnode_supported 13
+
+/* arm: Hypervisor supports ARM SMC calling convention. */
+#define XENFEAT_ARM_SMCCC_supported       14
+
+/*
+ * x86/PVH: If set, ACPI RSDP can be placed at any address. Otherwise RSDP
+ * must be located in lower 1MB, as required by ACPI Specification for IA-PC
+ * systems.
+ * This feature flag is only consulted if XEN_ELFNOTE_GUEST_OS contains
+ * the "linux" string.
+ */
+#define XENFEAT_linux_rsdp_unrestricted   15
+
+/*
+ * A direct-mapped (or 1:1 mapped) domain is a domain for which its
+ * local pages have gfn == mfn. If a domain is direct-mapped,
+ * XENFEAT_direct_mapped is set; otherwise XENFEAT_not_direct_mapped
+ * is set.
+ *
+ * If neither flag is set (e.g. older Xen releases) the assumptions are:
+ * - not auto_translated domains (x86 only) are always direct-mapped
+ * - on x86, auto_translated domains are not direct-mapped
+ * - on ARM, Dom0 is direct-mapped, DomUs are not
+ */
+#define XENFEAT_not_direct_mapped         16
+#define XENFEAT_direct_mapped             17
+
+/*
+ * Signal whether the domain is able to use the following hypercalls:
+ *
+ * VCPUOP_register_runstate_phys_area
+ * VCPUOP_register_vcpu_time_phys_area
+ */
+#define XENFEAT_runstate_phys_area	  18
+#define XENFEAT_vcpu_time_phys_area	  19
+
+#define XENFEAT_NR_SUBMAPS 1
+
+#endif /* __XEN_PUBLIC_FEATURES_H__ */

--- a/include/zephyr/xen/public/grant_table.h
+++ b/include/zephyr/xen/public/grant_table.h
@@ -123,8 +123,9 @@ typedef uint32_t grant_ref_t;
  */
 
 /*
- * Version 1 of the grant table entry structure is maintained purely
- * for backwards compatibility.  New guests should use version 2.
+ * Version 1 of the grant table entry structure is maintained largely for
+ * backwards compatibility.  New guests are recommended to support using
+ * version 2 to overcome version 1 limitations, but to default to version 1.
  */
 #if __XEN_INTERFACE_VERSION__ < 0x0003020a
 #define grant_entry_v1 grant_entry
@@ -208,6 +209,83 @@ typedef struct grant_entry_v1 grant_entry_v1_t;
 #define GTF_transfer_committed			(1U << _GTF_transfer_committed)
 #define _GTF_transfer_completed			(3)
 #define GTF_transfer_completed			(1U << _GTF_transfer_completed)
+/*
+ * Version 2 grant table entries.  These fulfil the same role as
+ * version 1 entries, but can represent more complicated operations.
+ * Any given domain will have either a version 1 or a version 2 table,
+ * and every entry in the table will be the same version.
+ *
+ * The interface by which domains use grant references does not depend
+ * on the grant table version in use by the other domain.
+ */
+#if __XEN_INTERFACE_VERSION__ >= 0x0003020a
+/*
+ * Version 1 and version 2 grant entries share a common prefix.  The
+ * fields of the prefix are documented as part of struct
+ * grant_entry_v1.
+ */
+struct grant_entry_header {
+	uint16_t flags;
+	domid_t  domid;
+};
+typedef struct grant_entry_header grant_entry_header_t;
+
+/*
+ * Version 2 of the grant entry structure.
+ */
+union grant_entry_v2 {
+	grant_entry_header_t hdr;
+
+	/*
+	 * This member is used for V1-style full page grants, where either:
+	 *
+	 * -- hdr.type is GTF_accept_transfer, or
+	 * -- hdr.type is GTF_permit_access and GTF_sub_page is not set.
+	 *
+	 * In that case, the frame field has the same semantics as the
+	 * field of the same name in the V1 entry structure.
+	 */
+	struct {
+		grant_entry_header_t hdr;
+		uint32_t pad0;
+		uint64_t frame;
+	} full_page;
+
+	/*
+	 * If the grant type is GTF_grant_access and GTF_sub_page is set,
+	 * @domid is allowed to access bytes [@page_off,@page_off+@length)
+	 * in frame @frame.
+	 */
+	struct {
+		grant_entry_header_t hdr;
+		uint16_t page_off;
+		uint16_t length;
+		uint64_t frame;
+	} sub_page;
+
+	/*
+	 * If the grant is GTF_transitive, @domid is allowed to use the
+	 * grant @gref in domain @trans_domid, as if it was the local
+	 * domain.  Obviously, the transitive access must be compatible
+	 * with the original grant.
+	 *
+	 * The current version of Xen does not allow transitive grants
+	 * to be mapped.
+	 */
+	struct {
+		grant_entry_header_t hdr;
+		domid_t trans_domid;
+		uint16_t pad0;
+		grant_ref_t gref;
+	} transitive;
+
+	uint32_t __spacer[4]; /* Pad to a power of two */
+};
+typedef union grant_entry_v2 grant_entry_v2_t;
+
+typedef uint16_t grant_status_t;
+
+#endif /* __XEN_INTERFACE_VERSION__ */
 
 /***********************************
  * GRANT TABLE QUERIES AND USES
@@ -324,7 +402,207 @@ struct gnttab_setup_table {
 typedef struct gnttab_setup_table gnttab_setup_table_t;
 DEFINE_XEN_GUEST_HANDLE(gnttab_setup_table_t);
 
+/*
+ * GNTTABOP_dump_table: Dump the contents of the grant table to the
+ * xen console. Debugging use only.
+ */
+struct gnttab_dump_table {
+	/* IN parameters. */
+	domid_t dom;
+	/* OUT parameters. */
+	int16_t status;               /* => enum grant_status */
+};
+typedef struct gnttab_dump_table gnttab_dump_table_t;
+DEFINE_XEN_GUEST_HANDLE(gnttab_dump_table_t);
 
+/*
+ * GNTTABOP_transfer: Transfer <frame> to a foreign domain. The foreign domain
+ * has previously registered its interest in the transfer via <domid, ref>.
+ *
+ * Note that, even if the transfer fails, the specified page no longer belongs
+ * to the calling domain *unless* the error is GNTST_bad_page.
+ *
+ * Note further that only PV guests can use this operation.
+ */
+struct gnttab_transfer {
+	/* IN parameters. */
+	xen_pfn_t     mfn;
+	domid_t       domid;
+	grant_ref_t   ref;
+	/* OUT parameters. */
+	int16_t       status;
+};
+typedef struct gnttab_transfer gnttab_transfer_t;
+DEFINE_XEN_GUEST_HANDLE(gnttab_transfer_t);
+
+
+/*
+ * GNTTABOP_copy: Hypervisor based copy
+ * source and destinations can be eithers MFNs or, for foreign domains,
+ * grant references. the foreign domain has to grant read/write access
+ * in its grant table.
+ *
+ * The flags specify what type source and destinations are (either MFN
+ * or grant reference).
+ *
+ * Note that this can also be used to copy data between two domains
+ * via a third party if the source and destination domains had previously
+ * grant appropriate access to their pages to the third party.
+ *
+ * source_offset specifies an offset in the source frame, dest_offset
+ * the offset in the target frame and  len specifies the number of
+ * bytes to be copied.
+ */
+
+#define _GNTCOPY_source_gref      (0)
+#define GNTCOPY_source_gref       (1<<_GNTCOPY_source_gref)
+#define _GNTCOPY_dest_gref        (1)
+#define GNTCOPY_dest_gref         (1<<_GNTCOPY_dest_gref)
+
+struct gnttab_copy {
+	/* IN parameters. */
+	struct gnttab_copy_ptr {
+		union {
+			grant_ref_t ref;
+			xen_pfn_t   gmfn;
+		} u;
+		domid_t  domid;
+		uint16_t offset;
+	} source, dest;
+	uint16_t      len;
+	uint16_t      flags;          /* GNTCOPY_* */
+	/* OUT parameters. */
+	int16_t       status;
+};
+typedef struct gnttab_copy  gnttab_copy_t;
+DEFINE_XEN_GUEST_HANDLE(gnttab_copy_t);
+
+/*
+ * GNTTABOP_query_size: Query the current and maximum sizes of the shared
+ * grant table.
+ * NOTES:
+ *  1. <dom> may be specified as DOMID_SELF.
+ *  2. Only a sufficiently-privileged domain may specify <dom> != DOMID_SELF.
+ */
+struct gnttab_query_size {
+	/* IN parameters. */
+	domid_t  dom;
+	/* OUT parameters. */
+	uint32_t nr_frames;
+	uint32_t max_nr_frames;
+	int16_t  status;              /* => enum grant_status */
+};
+typedef struct gnttab_query_size gnttab_query_size_t;
+DEFINE_XEN_GUEST_HANDLE(gnttab_query_size_t);
+
+/*
+ * GNTTABOP_unmap_and_replace: Destroy one or more grant-reference mappings
+ * tracked by <handle> but atomically replace the page table entry with one
+ * pointing to the machine address under <new_addr>.  <new_addr> will be
+ * redirected to the null entry.
+ * NOTES:
+ *  1. The call may fail in an undefined manner if either mapping is not
+ *     tracked by <handle>.
+ *  2. After executing a batch of unmaps, it is guaranteed that no stale
+ *     mappings will remain in the device or host TLBs.
+ */
+struct gnttab_unmap_and_replace {
+	/* IN parameters. */
+	uint64_t host_addr;
+	uint64_t new_addr;
+	grant_handle_t handle;
+	/* OUT parameters. */
+	int16_t  status;              /* => enum grant_status */
+};
+typedef struct gnttab_unmap_and_replace gnttab_unmap_and_replace_t;
+DEFINE_XEN_GUEST_HANDLE(gnttab_unmap_and_replace_t);
+
+#if __XEN_INTERFACE_VERSION__ >= 0x0003020a
+/*
+ * GNTTABOP_set_version: Request a particular version of the grant
+ * table shared table structure.  This operation may be used to toggle
+ * between different versions, but must be performed while no grants
+ * are active.  The only defined versions are 1 and 2.
+ */
+struct gnttab_set_version {
+	/* IN/OUT parameters */
+	uint32_t version;
+};
+typedef struct gnttab_set_version gnttab_set_version_t;
+DEFINE_XEN_GUEST_HANDLE(gnttab_set_version_t);
+
+
+/*
+ * GNTTABOP_get_status_frames: Get the list of frames used to store grant
+ * status for <dom>. In grant format version 2, the status is separated
+ * from the other shared grant fields to allow more efficient synchronization
+ * using barriers instead of atomic cmpexch operations.
+ * <nr_frames> specify the size of vector <frame_list>.
+ * The frame addresses are returned in the <frame_list>.
+ * Only <nr_frames> addresses are returned, even if the table is larger.
+ * NOTES:
+ *  1. <dom> may be specified as DOMID_SELF.
+ *  2. Only a sufficiently-privileged domain may specify <dom> != DOMID_SELF.
+ */
+struct gnttab_get_status_frames {
+	/* IN parameters. */
+	uint32_t nr_frames;
+	domid_t  dom;
+	/* OUT parameters. */
+	int16_t  status;              /* => enum grant_status */
+
+	XEN_GUEST_HANDLE(uint64_t) frame_list;
+};
+typedef struct gnttab_get_status_frames gnttab_get_status_frames_t;
+DEFINE_XEN_GUEST_HANDLE(gnttab_get_status_frames_t);
+
+/*
+ * GNTTABOP_get_version: Get the grant table version which is in
+ * effect for domain <dom>.
+ */
+struct gnttab_get_version {
+	/* IN parameters */
+	domid_t dom;
+	uint16_t pad;
+	/* OUT parameters */
+	uint32_t version;
+};
+typedef struct gnttab_get_version gnttab_get_version_t;
+DEFINE_XEN_GUEST_HANDLE(gnttab_get_version_t);
+
+/*
+ * GNTTABOP_swap_grant_ref: Swap the contents of two grant entries.
+ */
+struct gnttab_swap_grant_ref {
+	/* IN parameters */
+	grant_ref_t ref_a;
+	grant_ref_t ref_b;
+	/* OUT parameters */
+	int16_t status;             /* => enum grant_status */
+};
+typedef struct gnttab_swap_grant_ref gnttab_swap_grant_ref_t;
+DEFINE_XEN_GUEST_HANDLE(gnttab_swap_grant_ref_t);
+
+/*
+ * Issue one or more cache maintenance operations on a portion of a
+ * page granted to the calling domain by a foreign domain.
+ */
+struct gnttab_cache_flush {
+	union {
+		uint64_t dev_bus_addr;
+		grant_ref_t ref;
+	} a;
+	uint16_t offset; /* offset from start of grant */
+	uint16_t length; /* size within the grant */
+#define GNTTAB_CACHE_CLEAN          (1u<<0)
+#define GNTTAB_CACHE_INVAL          (1u<<1)
+#define GNTTAB_CACHE_SOURCE_GREF    (1u<<31)
+	uint32_t op;
+};
+typedef struct gnttab_cache_flush gnttab_cache_flush_t;
+DEFINE_XEN_GUEST_HANDLE(gnttab_cache_flush_t);
+
+#endif /* __XEN_INTERFACE_VERSION__ */
 
 /*
  * Bitfield values for gnttab_map_grant_ref.flags.
@@ -338,19 +616,19 @@ DEFINE_XEN_GUEST_HANDLE(gnttab_setup_table_t);
  /* Accesses to the granted frame will be restricted to read-only access. */
 #define _GNTMAP_readonly	(2)
 #define GNTMAP_readonly		(1<<_GNTMAP_readonly)
- /*
-  * GNTMAP_host_map subflag:
-  *  0 => The host mapping is usable only by the guest OS.
-  *  1 => The host mapping is usable by guest OS + current application.
-  */
+/*
+ * GNTMAP_host_map subflag:
+ *  0 => The host mapping is usable only by the guest OS.
+ *  1 => The host mapping is usable by guest OS + current application.
+ */
 #define _GNTMAP_application_map	(3)
 #define GNTMAP_application_map	(1<<_GNTMAP_application_map)
 
- /*
-  * GNTMAP_contains_pte subflag:
-  *  0 => This map request contains a host virtual address.
-  *  1 => This map request contains the machine addess of the PTE to update.
-  */
+/*
+ * GNTMAP_contains_pte subflag:
+ *  0 => This map request contains a host virtual address.
+ *  1 => This map request contains the machine addess of the PTE to update.
+ */
 #define _GNTMAP_contains_pte	(4)
 #define GNTMAP_contains_pte	(1<<_GNTMAP_contains_pte)
 
@@ -378,6 +656,7 @@ DEFINE_XEN_GUEST_HANDLE(gnttab_setup_table_t);
 #define GNTST_bad_copy_arg	(-10) /* copy arguments cross page boundary */
 #define GNTST_address_too_big	(-11) /* transfer page address too large */
 #define GNTST_eagain		(-12) /* Operation not done; try agains */
+#define GNTST_no_space		(-13) /* Out of space (handles etc).           */
 /* ` } */
 
 #define GNTTABOP_error_msgs {				\
@@ -393,7 +672,8 @@ DEFINE_XEN_GUEST_HANDLE(gnttab_setup_table_t);
 	"bad page",					\
 	"copy arguments cross page boundary",		\
 	"page address size too large",			\
-	"operation not done; try again"			\
+	"operation not done; try again",            \
+	"out of space",                             \
 }
 
 #endif /* __XEN_PUBLIC_GRANT_TABLE_H__ */

--- a/include/zephyr/xen/public/hvm/hvm_op.h
+++ b/include/zephyr/xen/public/hvm/hvm_op.h
@@ -26,6 +26,7 @@
 #define __XEN_PUBLIC_HVM_HVM_OP_H__
 
 #include "../xen.h"
+#include "../trace.h"
 
 /* Get/set subcommands: extra argument == pointer to xen_hvm_param struct. */
 #define HVMOP_set_param	0
@@ -38,5 +39,352 @@ struct xen_hvm_param {
 };
 typedef struct xen_hvm_param xen_hvm_param_t;
 DEFINE_XEN_GUEST_HANDLE(xen_hvm_param_t);
+
+struct xen_hvm_altp2m_suppress_ve {
+	uint16_t view;
+	uint8_t suppress_ve; /* Boolean type. */
+	uint8_t pad1;
+	uint32_t pad2;
+	uint64_t gfn;
+};
+
+struct xen_hvm_altp2m_suppress_ve_multi {
+	uint16_t view;
+	uint8_t suppress_ve; /* Boolean type. */
+	uint8_t pad1;
+	int32_t first_error; /* Should be set to 0. */
+	uint64_t first_gfn; /* Value may be updated. */
+	uint64_t last_gfn;
+	uint64_t first_error_gfn; /* Gfn of the first error. */
+};
+
+#if __XEN_INTERFACE_VERSION__ < 0x00040900
+
+/* Set the logical level of one of a domain's PCI INTx wires. */
+#define HVMOP_set_pci_intx_level  2
+struct xen_hvm_set_pci_intx_level {
+	/* Domain to be updated. */
+	domid_t  domid;
+	/* PCI INTx identification in PCI topology (domain:bus:device:intx). */
+	uint8_t  domain, bus, device, intx;
+	/* Assertion level (0 = unasserted, 1 = asserted). */
+	uint8_t  level;
+};
+typedef struct xen_hvm_set_pci_intx_level xen_hvm_set_pci_intx_level_t;
+DEFINE_XEN_GUEST_HANDLE(xen_hvm_set_pci_intx_level_t);
+
+/* Set the logical level of one of a domain's ISA IRQ wires. */
+#define HVMOP_set_isa_irq_level   3
+struct xen_hvm_set_isa_irq_level {
+	/* Domain to be updated. */
+	domid_t  domid;
+	/* ISA device identification, by ISA IRQ (0-15). */
+	uint8_t  isa_irq;
+	/* Assertion level (0 = unasserted, 1 = asserted). */
+	uint8_t  level;
+};
+typedef struct xen_hvm_set_isa_irq_level xen_hvm_set_isa_irq_level_t;
+DEFINE_XEN_GUEST_HANDLE(xen_hvm_set_isa_irq_level_t);
+
+#define HVMOP_set_pci_link_route  4
+struct xen_hvm_set_pci_link_route {
+	/* Domain to be updated. */
+	domid_t  domid;
+	/* PCI link identifier (0-3). */
+	uint8_t  link;
+	/* ISA IRQ (1-15), or 0 (disable link). */
+	uint8_t  isa_irq;
+};
+typedef struct xen_hvm_set_pci_link_route xen_hvm_set_pci_link_route_t;
+DEFINE_XEN_GUEST_HANDLE(xen_hvm_set_pci_link_route_t);
+
+#endif /* __XEN_INTERFACE_VERSION__ < 0x00040900 */
+
+/* Flushes all VCPU TLBs: @arg must be NULL. */
+#define HVMOP_flush_tlbs          5
+
+/*
+ * hvmmem_type_t should not be defined when generating the corresponding
+ * compat header. This will ensure that the improperly named HVMMEM_(*)
+ * values are defined only once.
+ */
+#ifndef XEN_GENERATING_COMPAT_HEADERS
+
+typedef enum {
+	HVMMEM_ram_rw,             /* Normal read/write guest RAM */
+	HVMMEM_ram_ro,             /* Read-only; writes are discarded */
+	HVMMEM_mmio_dm,            /* Reads and write go to the device model */
+#if __XEN_INTERFACE_VERSION__ < 0x00040700
+	HVMMEM_mmio_write_dm,      /* Read-only; writes go to the device model */
+#else
+	HVMMEM_unused, /*
+			* Placeholder; setting memory to this type
+			* will fail for code after 4.7.0
+			*/
+#endif
+	HVMMEM_ioreq_server   /*
+			       * Memory type claimed by an ioreq server; type
+			       * changes to this value are only allowed after
+			       * an ioreq server has claimed its ownership.
+			       * Only pages with HVMMEM_ram_rw are allowed to
+			       * change to this type; conversely, pages with
+			       * this type are only allowed to be changed back
+			       * to HVMMEM_ram_rw.
+			       */
+} hvmmem_type_t;
+
+#endif /* XEN_GENERATING_COMPAT_HEADERS */
+
+/* Hint from PV drivers for pagetable destruction. */
+#define HVMOP_pagetable_dying        9
+struct xen_hvm_pagetable_dying {
+	/* Domain with a pagetable about to be destroyed. */
+	domid_t  domid;
+	uint16_t pad[3]; /* align next field on 8-byte boundary */
+	/* guest physical address of the toplevel pagetable dying */
+	uint64_t gpa;
+};
+typedef struct xen_hvm_pagetable_dying xen_hvm_pagetable_dying_t;
+DEFINE_XEN_GUEST_HANDLE(xen_hvm_pagetable_dying_t);
+
+/* Get the current Xen time, in nanoseconds since system boot. */
+#define HVMOP_get_time              10
+struct xen_hvm_get_time {
+	uint64_t now;      /* OUT */
+};
+typedef struct xen_hvm_get_time xen_hvm_get_time_t;
+DEFINE_XEN_GUEST_HANDLE(xen_hvm_get_time_t);
+
+#define HVMOP_xentrace              11
+struct xen_hvm_xentrace {
+	uint16_t event, extra_bytes;
+	uint8_t extra[TRACE_EXTRA_MAX * sizeof(uint32_t)];
+};
+typedef struct xen_hvm_xentrace xen_hvm_xentrace_t;
+DEFINE_XEN_GUEST_HANDLE(xen_hvm_xentrace_t);
+
+/* Following tools-only interfaces may change in future. */
+#ifdef CONFIG_XEN_INITIAL_DOMAIN
+
+/* Deprecated by XENMEM_access_op_set_access */
+#define HVMOP_set_mem_access        12
+
+/* Deprecated by XENMEM_access_op_get_access */
+#define HVMOP_get_mem_access        13
+
+#endif /* CONFIG_XEN_INITIAL_DOMAIN */
+
+#define HVMOP_get_mem_type    15
+/* Return hvmmem_type_t for the specified pfn. */
+struct xen_hvm_get_mem_type {
+	/* Domain to be queried. */
+	domid_t domid;
+	/* OUT variable. */
+	uint16_t mem_type;
+	uint16_t pad[2]; /* align next field on 8-byte boundary */
+	/* IN variable. */
+	uint64_t pfn;
+};
+typedef struct xen_hvm_get_mem_type xen_hvm_get_mem_type_t;
+DEFINE_XEN_GUEST_HANDLE(xen_hvm_get_mem_type_t);
+
+/* Following tools-only interfaces may change in future. */
+#ifdef CONFIG_XEN_INITIAL_DOMAIN
+
+/*
+ * Definitions relating to DMOP_create_ioreq_server. (Defined here for
+ * backwards compatibility).
+ */
+
+#define HVM_IOREQSRV_BUFIOREQ_OFF    0
+#define HVM_IOREQSRV_BUFIOREQ_LEGACY 1
+/*
+ * Use this when read_pointer gets updated atomically and
+ * the pointer pair gets read atomically:
+ */
+#define HVM_IOREQSRV_BUFIOREQ_ATOMIC 2
+
+#endif /* CONFIG_XEN_INITIAL_DOMAIN */
+
+#if defined(CONFIG_X86) || defined(CONFIG_X86_64)
+
+/*
+ * HVMOP_set_evtchn_upcall_vector: Set a <vector> that should be used for event
+ *                                 channel upcalls on the specified <vcpu>. If set,
+ *                                 this vector will be used in preference to the
+ *                                 domain global callback via (see
+ *                                 HVM_PARAM_CALLBACK_IRQ).
+ */
+#define HVMOP_set_evtchn_upcall_vector 23
+struct xen_hvm_evtchn_upcall_vector {
+	uint32_t vcpu;
+	uint8_t vector;
+};
+typedef struct xen_hvm_evtchn_upcall_vector xen_hvm_evtchn_upcall_vector_t;
+DEFINE_XEN_GUEST_HANDLE(xen_hvm_evtchn_upcall_vector_t);
+
+#endif /* defined(CONFIG_X86) || defined(CONFIG_X86_64) */
+
+#define HVMOP_guest_request_vm_event 24
+
+/* HVMOP_altp2m: perform altp2m state operations */
+#define HVMOP_altp2m 25
+
+#define HVMOP_ALTP2M_INTERFACE_VERSION 0x00000001
+
+struct xen_hvm_altp2m_domain_state {
+	/* IN or OUT variable on/off */
+	uint8_t state;
+};
+typedef struct xen_hvm_altp2m_domain_state xen_hvm_altp2m_domain_state_t;
+DEFINE_XEN_GUEST_HANDLE(xen_hvm_altp2m_domain_state_t);
+
+struct xen_hvm_altp2m_vcpu_enable_notify {
+	uint32_t vcpu_id;
+	uint32_t pad;
+	/* #VE info area gfn */
+	uint64_t gfn;
+};
+typedef struct xen_hvm_altp2m_vcpu_enable_notify xen_hvm_altp2m_vcpu_enable_notify_t;
+DEFINE_XEN_GUEST_HANDLE(xen_hvm_altp2m_vcpu_enable_notify_t);
+
+struct xen_hvm_altp2m_vcpu_disable_notify {
+	uint32_t vcpu_id;
+};
+typedef struct xen_hvm_altp2m_vcpu_disable_notify xen_hvm_altp2m_vcpu_disable_notify_t;
+DEFINE_XEN_GUEST_HANDLE(xen_hvm_altp2m_vcpu_disable_notify_t);
+
+struct xen_hvm_altp2m_view {
+	/* IN/OUT variable */
+	uint16_t view;
+	uint16_t hvmmem_default_access; /* xenmem_access_t */
+};
+typedef struct xen_hvm_altp2m_view xen_hvm_altp2m_view_t;
+DEFINE_XEN_GUEST_HANDLE(xen_hvm_altp2m_view_t);
+
+#if __XEN_INTERFACE_VERSION__ < 0x00040a00
+struct xen_hvm_altp2m_set_mem_access {
+	/* view */
+	uint16_t view;
+	/* Memory type */
+	uint16_t access; /* xenmem_access_t */
+	uint32_t pad;
+	/* gfn */
+	uint64_t gfn;
+};
+typedef struct xen_hvm_altp2m_set_mem_access xen_hvm_altp2m_set_mem_access_t;
+DEFINE_XEN_GUEST_HANDLE(xen_hvm_altp2m_set_mem_access_t);
+#endif /* __XEN_INTERFACE_VERSION__ < 0x00040a00 */
+
+struct xen_hvm_altp2m_mem_access {
+	/* view */
+	uint16_t view;
+	/* Memory type */
+	uint16_t access; /* xenmem_access_t */
+	uint32_t pad;
+	/* gfn */
+	uint64_t gfn;
+};
+typedef struct xen_hvm_altp2m_mem_access xen_hvm_altp2m_mem_access_t;
+DEFINE_XEN_GUEST_HANDLE(xen_hvm_altp2m_mem_access_t);
+
+struct xen_hvm_altp2m_set_mem_access_multi {
+	/* view */
+	uint16_t view;
+	uint16_t pad;
+	/* Number of pages */
+	uint32_t nr;
+	/*
+	 * Used for continuation purposes.
+	 * Must be set to zero upon initial invocation.
+	 */
+	uint64_t opaque;
+	/* List of pfns to set access for */
+	XEN_GUEST_HANDLE(const_uint64) pfn_list;
+	/* Corresponding list of access settings for pfn_list */
+	XEN_GUEST_HANDLE(const_uint8) access_list;
+};
+
+struct xen_hvm_altp2m_change_gfn {
+	/* view */
+	uint16_t view;
+	uint16_t pad1;
+	uint32_t pad2;
+	/* old gfn */
+	uint64_t old_gfn;
+	/* new gfn, INVALID_GFN (~0UL) means revert */
+	uint64_t new_gfn;
+};
+typedef struct xen_hvm_altp2m_change_gfn xen_hvm_altp2m_change_gfn_t;
+DEFINE_XEN_GUEST_HANDLE(xen_hvm_altp2m_change_gfn_t);
+
+struct xen_hvm_altp2m_get_vcpu_p2m_idx {
+	uint32_t vcpu_id;
+	uint16_t altp2m_idx;
+};
+
+struct xen_hvm_altp2m_set_visibility {
+	uint16_t altp2m_idx;
+	uint8_t visible;
+	uint8_t pad;
+};
+
+struct xen_hvm_altp2m_op {
+	uint32_t version;   /* HVMOP_ALTP2M_INTERFACE_VERSION */
+	uint32_t cmd;
+/* Get/set the altp2m state for a domain */
+#define HVMOP_altp2m_get_domain_state     1
+#define HVMOP_altp2m_set_domain_state     2
+/* Set a given VCPU to receive altp2m event notifications */
+#define HVMOP_altp2m_vcpu_enable_notify   3
+/* Create a new view */
+#define HVMOP_altp2m_create_p2m           4
+/* Destroy a view */
+#define HVMOP_altp2m_destroy_p2m          5
+/* Switch view for an entire domain */
+#define HVMOP_altp2m_switch_p2m           6
+/* Notify that a page of memory is to have specific access types */
+#define HVMOP_altp2m_set_mem_access       7
+/* Change a p2m entry to have a different gfn->mfn mapping */
+#define HVMOP_altp2m_change_gfn           8
+/* Set access for an array of pages */
+#define HVMOP_altp2m_set_mem_access_multi 9
+/* Set the "Suppress #VE" bit on a page */
+#define HVMOP_altp2m_set_suppress_ve      10
+/* Get the "Suppress #VE" bit of a page */
+#define HVMOP_altp2m_get_suppress_ve      11
+/* Get the access of a page of memory from a certain view */
+#define HVMOP_altp2m_get_mem_access       12
+/* Disable altp2m event notifications for a given VCPU */
+#define HVMOP_altp2m_vcpu_disable_notify  13
+/* Get the active vcpu p2m index */
+#define HVMOP_altp2m_get_p2m_idx          14
+/* Set the "Suppress #VE" bit for a range of pages */
+#define HVMOP_altp2m_set_suppress_ve_multi 15
+/* Set visibility for a given altp2m view */
+#define HVMOP_altp2m_set_visibility       16
+	domid_t domain;
+	uint16_t pad1;
+	uint32_t pad2;
+	union {
+		struct xen_hvm_altp2m_domain_state         domain_state;
+		struct xen_hvm_altp2m_vcpu_enable_notify   enable_notify;
+		struct xen_hvm_altp2m_view                 view;
+#if __XEN_INTERFACE_VERSION__ < 0x00040a00
+		struct xen_hvm_altp2m_set_mem_access       set_mem_access;
+#endif /* __XEN_INTERFACE_VERSION__ < 0x00040a00 */
+		struct xen_hvm_altp2m_mem_access           mem_access;
+		struct xen_hvm_altp2m_change_gfn           change_gfn;
+		struct xen_hvm_altp2m_set_mem_access_multi set_mem_access_multi;
+		struct xen_hvm_altp2m_suppress_ve          suppress_ve;
+		struct xen_hvm_altp2m_suppress_ve_multi    suppress_ve_multi;
+		struct xen_hvm_altp2m_vcpu_disable_notify  disable_notify;
+		struct xen_hvm_altp2m_get_vcpu_p2m_idx     get_vcpu_p2m_idx;
+		struct xen_hvm_altp2m_set_visibility       set_visibility;
+		uint8_t pad[64];
+	} u;
+};
+typedef struct xen_hvm_altp2m_op xen_hvm_altp2m_op_t;
+DEFINE_XEN_GUEST_HANDLE(xen_hvm_altp2m_op_t);
 
 #endif /* __XEN_PUBLIC_HVM_HVM_OP_H__ */

--- a/include/zephyr/xen/public/hvm/params.h
+++ b/include/zephyr/xen/public/hvm/params.h
@@ -27,6 +27,67 @@
 
 #include "hvm_op.h"
 
+/* These parameters are deprecated and their meaning is undefined. */
+#ifdef CONFIG_XEN_INITIAL_DOMAIN
+
+#define HVM_PARAM_PAE_ENABLED                4
+#define HVM_PARAM_DM_DOMAIN                 13
+#define HVM_PARAM_MEMORY_EVENT_CR0          20
+#define HVM_PARAM_MEMORY_EVENT_CR3          21
+#define HVM_PARAM_MEMORY_EVENT_CR4          22
+#define HVM_PARAM_MEMORY_EVENT_INT3         23
+#define HVM_PARAM_NESTEDHVM                 24
+#define HVM_PARAM_MEMORY_EVENT_SINGLE_STEP  25
+#define HVM_PARAM_BUFIOREQ_EVTCHN           26
+#define HVM_PARAM_MEMORY_EVENT_MSR          30
+
+#endif /* CONFIG_XEN_INITIAL_DOMAIN */
+/*
+ * Parameter space for HVMOP_{set,get}_param.
+ */
+
+#define HVM_PARAM_CALLBACK_IRQ 0
+#define HVM_PARAM_CALLBACK_IRQ_TYPE_MASK xen_mk_ullong(0xFF00000000000000)
+/*
+ * How should CPU0 event-channel notifications be delivered?
+ *
+ * If val == 0 then CPU0 event-channel notifications are not delivered.
+ * If val != 0, val[63:56] encodes the type, as follows:
+ */
+
+#define HVM_PARAM_CALLBACK_TYPE_GSI      0
+/*
+ * val[55:0] is a delivery GSI.  GSI 0 cannot be used, as it aliases val == 0,
+ * and disables all notifications.
+ */
+
+#define HVM_PARAM_CALLBACK_TYPE_PCI_INTX 1
+/*
+ * val[55:0] is a delivery PCI INTx line:
+ * Domain = val[47:32], Bus = val[31:16] DevFn = val[15:8], IntX = val[1:0]
+ */
+
+#if defined(CONFIG_X86) || defined(CONFIG_X86_64)
+#define HVM_PARAM_CALLBACK_TYPE_VECTOR   2
+/*
+ * val[7:0] is a vector number.  Check for XENFEAT_hvm_callback_vector to know
+ * if this delivery method is available.
+ */
+#elif defined(CONFIG_ARM) || defined(CONFIG_ARM64)
+#define HVM_PARAM_CALLBACK_TYPE_PPI      2
+/*
+ * val[55:16] needs to be zero.
+ * val[15:8] is interrupt flag of the PPI used by event-channel:
+ *  bit 8: the PPI is edge(1) or level(0) triggered
+ *  bit 9: the PPI is active low(1) or high(0)
+ * val[7:0] is a PPI number used by event-channel.
+ * This is only used by ARM/ARM64 and masking/eoi the interrupt associated to
+ * the notification is handled by the interrupt controller.
+ */
+#define HVM_PARAM_CALLBACK_TYPE_PPI_FLAG_MASK      0xFF00
+#define HVM_PARAM_CALLBACK_TYPE_PPI_FLAG_LOW_LEVEL 2
+#endif
+
 /*
  * These are not used by Xen. They are here for convenience of HVM-guest
  * xenbus implementations.
@@ -34,8 +95,226 @@
 #define HVM_PARAM_STORE_PFN		1
 #define HVM_PARAM_STORE_EVTCHN		2
 
+#define HVM_PARAM_IOREQ_PFN    5
+
+#define HVM_PARAM_BUFIOREQ_PFN 6
+
+#if defined(CONFIG_X86) || defined(CONFIG_X86_64)
+
+/**
+ * Viridian enlightenments
+ *
+ * (See http://download.microsoft.com/download/A/B/4/AB43A34E-BDD0-4FA6-BDEF-79EEF16E880B/Hypervisor%20Top%20Level%20Functional%20Specification%20v4.0.docx)
+ *
+ * To expose viridian enlightenments to the guest set this parameter
+ * to the desired feature mask. The base feature set must be present
+ * in any valid feature mask.
+ */
+#define HVM_PARAM_VIRIDIAN     9
+
+/**
+ * Base+Freq viridian feature sets:
+ *
+ * - Hypercall MSRs (HV_X64_MSR_GUEST_OS_ID and HV_X64_MSR_HYPERCALL)
+ * - APIC access MSRs (HV_X64_MSR_EOI, HV_X64_MSR_ICR and HV_X64_MSR_TPR)
+ * - Virtual Processor index MSR (HV_X64_MSR_VP_INDEX)
+ * - Timer frequency MSRs (HV_X64_MSR_TSC_FREQUENCY and
+ *   HV_X64_MSR_APIC_FREQUENCY)
+ */
+#define _HVMPV_base_freq 0
+#define HVMPV_base_freq  (1 << _HVMPV_base_freq)
+
+/* Feature set modifications */
+
+/**
+ * Disable timer frequency MSRs (HV_X64_MSR_TSC_FREQUENCY and
+ * HV_X64_MSR_APIC_FREQUENCY).
+ * This modification restores the viridian feature set to the
+ * original 'base' set exposed in releases prior to Xen 4.4.
+ */
+#define _HVMPV_no_freq 1
+#define HVMPV_no_freq  (1 << _HVMPV_no_freq)
+
+/* Enable Partition Time Reference Counter (HV_X64_MSR_TIME_REF_COUNT) */
+#define _HVMPV_time_ref_count 2
+#define HVMPV_time_ref_count  (1 << _HVMPV_time_ref_count)
+
+/* Enable Reference TSC Page (HV_X64_MSR_REFERENCE_TSC) */
+#define _HVMPV_reference_tsc 3
+#define HVMPV_reference_tsc  (1 << _HVMPV_reference_tsc)
+
+/* Use Hypercall for remote TLB flush */
+#define _HVMPV_hcall_remote_tlb_flush 4
+#define HVMPV_hcall_remote_tlb_flush (1 << _HVMPV_hcall_remote_tlb_flush)
+
+/* Use APIC assist */
+#define _HVMPV_apic_assist 5
+#define HVMPV_apic_assist (1 << _HVMPV_apic_assist)
+
+/* Enable crash MSRs */
+#define _HVMPV_crash_ctl 6
+#define HVMPV_crash_ctl (1 << _HVMPV_crash_ctl)
+
+/* Enable SYNIC MSRs */
+#define _HVMPV_synic 7
+#define HVMPV_synic (1 << _HVMPV_synic)
+
+/* Enable STIMER MSRs */
+#define _HVMPV_stimer 8
+#define HVMPV_stimer (1 << _HVMPV_stimer)
+
+/* Use Synthetic Cluster IPI Hypercall */
+#define _HVMPV_hcall_ipi 9
+#define HVMPV_hcall_ipi (1 << _HVMPV_hcall_ipi)
+
+/* Enable ExProcessorMasks */
+#define _HVMPV_ex_processor_masks 10
+#define HVMPV_ex_processor_masks (1 << _HVMPV_ex_processor_masks)
+
+/* Allow more than 64 VPs */
+#define _HVMPV_no_vp_limit 11
+#define HVMPV_no_vp_limit (1 << _HVMPV_no_vp_limit)
+
+/* Enable vCPU hotplug */
+#define _HVMPV_cpu_hotplug 12
+#define HVMPV_cpu_hotplug (1 << _HVMPV_cpu_hotplug)
+
+#define HVMPV_feature_mask \
+	(HVMPV_base_freq | \
+	 HVMPV_no_freq | \
+	 HVMPV_time_ref_count | \
+	 HVMPV_reference_tsc | \
+	 HVMPV_hcall_remote_tlb_flush | \
+	 HVMPV_apic_assist | \
+	 HVMPV_crash_ctl | \
+	 HVMPV_synic | \
+	 HVMPV_stimer | \
+	 HVMPV_hcall_ipi | \
+	 HVMPV_ex_processor_masks | \
+	 HVMPV_no_vp_limit | \
+	 HVMPV_cpu_hotplug)
+
+#endif
+
+/**
+ * Set mode for virtual timers (currently x86 only):
+ *  delay_for_missed_ticks (default):
+ *   Do not advance a vcpu's time beyond the correct delivery time for
+ *   interrupts that have been missed due to preemption. Deliver missed
+ *   interrupts when the vcpu is rescheduled and advance the vcpu's virtual
+ *   time stepwise for each one.
+ *  no_delay_for_missed_ticks:
+ *   As above, missed interrupts are delivered, but guest time always tracks
+ *   wallclock (i.e., real) time while doing so.
+ *  no_missed_ticks_pending:
+ *   No missed interrupts are held pending. Instead, to ensure ticks are
+ *   delivered at some non-zero rate, if we detect missed ticks then the
+ *   internal tick alarm is not disabled if the VCPU is preempted during the
+ *   next tick period.
+ *  one_missed_tick_pending:
+ *   Missed interrupts are collapsed together and delivered as one 'late tick'.
+ *   Guest time always tracks wallclock (i.e., real) time.
+ */
+#define HVM_PARAM_TIMER_MODE   10
+#define HVMPTM_delay_for_missed_ticks    0
+#define HVMPTM_no_delay_for_missed_ticks 1
+#define HVMPTM_no_missed_ticks_pending   2
+#define HVMPTM_one_missed_tick_pending   3
+
+/* Boolean: Enable virtual HPET (high-precision event timer)? (x86-only) */
+#define HVM_PARAM_HPET_ENABLED 11
+
+/* Identity-map page directory used by Intel EPT when CR0.PG=0. */
+#define HVM_PARAM_IDENT_PT     12
+
+/* ACPI S state: currently support S0 and S3 on x86. */
+#define HVM_PARAM_ACPI_S_STATE 14
+
+/* TSS used on Intel when CR0.PE=0. */
+#define HVM_PARAM_VM86_TSS     15
+
+/* Boolean: Enable aligning all periodic vpts to reduce interrupts */
+#define HVM_PARAM_VPT_ALIGN    16
 /* Console debug shared memory ring and event channel */
 #define HVM_PARAM_CONSOLE_PFN		17
 #define HVM_PARAM_CONSOLE_EVTCHN	18
+
+/**
+ * Select location of ACPI PM1a and TMR control blocks. Currently two locations
+ * are supported, specified by version 0 or 1 in this parameter:
+ *   - 0: default, use the old addresses
+ *        PM1A_EVT == 0x1f40; PM1A_CNT == 0x1f44; PM_TMR == 0x1f48
+ *   - 1: use the new default qemu addresses
+ *        PM1A_EVT == 0xb000; PM1A_CNT == 0xb004; PM_TMR == 0xb008
+ * You can find these address definitions in <hvm/ioreq.h>
+ */
+#define HVM_PARAM_ACPI_IOPORTS_LOCATION 19
+
+/* Params for the mem event rings */
+#define HVM_PARAM_PAGING_RING_PFN   27
+#define HVM_PARAM_MONITOR_RING_PFN  28
+#define HVM_PARAM_SHARING_RING_PFN  29
+
+/* SHUTDOWN_* action in case of a triple fault */
+#define HVM_PARAM_TRIPLE_FAULT_REASON 31
+
+#define HVM_PARAM_IOREQ_SERVER_PFN 32
+#define HVM_PARAM_NR_IOREQ_SERVER_PAGES 33
+
+/* Location of the VM Generation ID in guest physical address space. */
+#define HVM_PARAM_VM_GENERATION_ID_ADDR 34
+
+/**
+ * Set mode for altp2m:
+ *  disabled: don't activate altp2m (default)
+ *  mixed: allow access to all altp2m ops for both in-guest and external tools
+ *  external: allow access to external privileged tools only
+ *  limited: guest only has limited access (ie. control VMFUNC and #VE)
+ *
+ * Note that 'mixed' mode has not been evaluated for safety from a
+ * security perspective.  Before using this mode in a
+ * security-critical environment, each subop should be evaluated for
+ * safety, with unsafe subops blacklisted in XSM.
+ */
+#define HVM_PARAM_ALTP2M       35
+#define XEN_ALTP2M_disabled      0
+#define XEN_ALTP2M_mixed         1
+#define XEN_ALTP2M_external      2
+#define XEN_ALTP2M_limited       3
+
+/**
+ * Size of the x87 FPU FIP/FDP registers that the hypervisor needs to
+ * save/restore.  This is a workaround for a hardware limitation that
+ * does not allow the full FIP/FDP and FCS/FDS to be restored.
+ *
+ * Valid values are:
+ *
+ * 8: save/restore 64-bit FIP/FDP and clear FCS/FDS (default if CPU
+ *    has FPCSDS feature).
+ *
+ * 4: save/restore 32-bit FIP/FDP, FCS/FDS, and clear upper 32-bits of
+ *    FIP/FDP.
+ *
+ * 0: allow hypervisor to choose based on the value of FIP/FDP
+ *    (default if CPU does not have FPCSDS).
+ *
+ * If FPCSDS (bit 13 in CPUID leaf 0x7, subleaf 0x0) is set, the CPU
+ * never saves FCS/FDS and this parameter should be left at the
+ * default of 8.
+ */
+#define HVM_PARAM_X87_FIP_WIDTH 36
+
+/**
+ * TSS (and its size) used on Intel when CR0.PE=0. The address occupies
+ * the low 32 bits, while the size is in the high 32 ones.
+ */
+#define HVM_PARAM_VM86_TSS_SIZED 37
+
+/* Enable MCA capabilities. */
+#define HVM_PARAM_MCA_CAP 38
+#define XEN_HVM_MCA_CAP_LMCE   (xen_mk_ullong(1) << 0)
+#define XEN_HVM_MCA_CAP_MASK   XEN_HVM_MCA_CAP_LMCE
+
+#define HVM_NR_PARAMS 39
 
 #endif /* __XEN_PUBLIC_HVM_PARAMS_H__ */

--- a/include/zephyr/xen/public/hvm/save.h
+++ b/include/zephyr/xen/public/hvm/save.h
@@ -1,0 +1,73 @@
+/* SPDX-License-Identifier: MIT */
+
+/******************************************************************************
+ * hvm/save.h
+ *
+ * Structure definitions for HVM state that is held by Xen and must
+ * be saved along with the domain's memory and device-model state.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Copyright (c) 2007 XenSource Ltd.
+ */
+
+#ifndef __XEN_PUBLIC_HVM_SAVE_H__
+#define __XEN_PUBLIC_HVM_SAVE_H__
+
+/*
+ * Each entry is preceded by a descriptor giving its type and length
+ */
+struct hvm_save_descriptor {
+	uint16_t typecode;          /* Used to demux the various types below */
+	uint16_t instance;          /* Further demux within a type */
+	uint32_t length;            /* In bytes, *not* including this descriptor */
+};
+
+
+/*
+ * Each entry has a datatype associated with it: for example, the CPU state
+ * is saved as a HVM_SAVE_TYPE(CPU), which has HVM_SAVE_LENGTH(CPU),
+ * and is identified by a descriptor with typecode HVM_SAVE_CODE(CPU).
+ * DECLARE_HVM_SAVE_TYPE binds these things together with some type-system
+ * ugliness.
+ */
+# define DECLARE_HVM_SAVE_TYPE_COMPAT(_x, _code, _type, _ctype, _fix)     \
+	struct __HVM_SAVE_TYPE_##_x { _type t; char c[_code]; char cpt[2]; }
+
+# define DECLARE_HVM_SAVE_TYPE(_x, _code, _type)                         \
+	struct __HVM_SAVE_TYPE_##_x { _type t; char c[_code]; char cpt[1]; }
+
+#define HVM_SAVE_TYPE(_x) __typeof__(((struct __HVM_SAVE_TYPE_##_x *)NULL)->t)
+#define HVM_SAVE_LENGTH(_x) (sizeof(HVM_SAVE_TYPE(_x)))
+#define HVM_SAVE_CODE(_x) (sizeof(((struct __HVM_SAVE_TYPE_##_x *)NULL)->c))
+
+/*
+ * The series of save records is teminated by a zero-type, zero-length
+ * descriptor.
+ */
+struct hvm_save_end {};
+DECLARE_HVM_SAVE_TYPE(END, 0, struct hvm_save_end);
+
+#if defined(CONFIG_ARM) || defined(CONFIG_ARM64)
+#include "../arch-arm/hvm/save.h"
+#else
+#error "unsupported architecture"
+#endif
+
+#endif /* __XEN_PUBLIC_HVM_SAVE_H__ */

--- a/include/zephyr/xen/public/memory.h
+++ b/include/zephyr/xen/public/memory.h
@@ -30,9 +30,37 @@
 #define __XEN_PUBLIC_MEMORY_H__
 
 #include "xen.h"
+#include "physdev.h"
 
+/*
+ * Increase or decrease the specified domain's memory reservation. Returns the
+ * number of extents successfully allocated or freed.
+ * arg == addr of struct xen_memory_reservation.
+ */
+#define XENMEM_increase_reservation 0
+#define XENMEM_decrease_reservation 1
 #define XENMEM_populate_physmap		6
 
+#if __XEN_INTERFACE_VERSION__ >= 0x00030209
+/*
+ * Maximum # bits addressable by the user of the allocated region (e.g., I/O
+ * devices often have a 32-bit limitation even in 64-bit systems). If zero
+ * then the user has no addressing restriction. This field is not used by
+ * XENMEM_decrease_reservation.
+ */
+#define XENMEMF_address_bits(x)     (x)
+#define XENMEMF_get_address_bits(x) ((x) & 0xffu)
+/* NUMA node to allocate from. */
+#define XENMEMF_node(x)     (((x) + 1) << 8)
+#define XENMEMF_get_node(x) ((((x) >> 8) - 1) & 0xffu)
+/* Flag to populate physmap with populate-on-demand entries */
+#define XENMEMF_populate_on_demand (1<<16)
+/* Flag to request allocation only from the node specified */
+#define XENMEMF_exact_node_request  (1<<17)
+#define XENMEMF_exact_node(n) (XENMEMF_node(n) | XENMEMF_exact_node_request)
+/* Flag to indicate the node specified is virtual node */
+#define XENMEMF_vnode  (1<<18)
+#endif
 struct xen_memory_reservation {
 
 	/*
@@ -68,6 +96,175 @@ struct xen_memory_reservation {
 };
 typedef struct xen_memory_reservation xen_memory_reservation_t;
 DEFINE_XEN_GUEST_HANDLE(xen_memory_reservation_t);
+/*
+ * An atomic exchange of memory pages. If return code is zero then
+ * @out.extent_list provides GMFNs of the newly-allocated memory.
+ * Returns zero on complete success, otherwise a negative error code.
+ * On complete success then always @nr_exchanged == @in.nr_extents.
+ * On partial success @nr_exchanged indicates how much work was done.
+ *
+ * Note that only PV guests can use this operation.
+ */
+#define XENMEM_exchange             11
+struct xen_memory_exchange {
+	/*
+	 * [IN] Details of memory extents to be exchanged (GMFN bases).
+	 * Note that @in.address_bits is ignored and unused.
+	 */
+	struct xen_memory_reservation in;
+
+	/*
+	 * [IN/OUT] Details of new memory extents.
+	 * We require that:
+	 *  1. @in.domid == @out.domid
+	 *  2. @in.nr_extents  << @in.extent_order ==
+	 *     @out.nr_extents << @out.extent_order
+	 *  3. @in.extent_start and @out.extent_start lists must not overlap
+	 *  4. @out.extent_start lists GPFN bases to be populated
+	 *  5. @out.extent_start is overwritten with allocated GMFN bases
+	 */
+	struct xen_memory_reservation out;
+
+	/*
+	 * [OUT] Number of input extents that were successfully exchanged:
+	 *  1. The first @nr_exchanged input extents were successfully
+	 *     deallocated.
+	 *  2. The corresponding first entries in the output extent list correctly
+	 *     indicate the GMFNs that were successfully exchanged.
+	 *  3. All other input and output extents are untouched.
+	 *  4. If not all input exents are exchanged then the return code of this
+	 *     command will be non-zero.
+	 *  5. THIS FIELD MUST BE INITIALISED TO ZERO BY THE CALLER!
+	 */
+	xen_ulong_t nr_exchanged;
+};
+typedef struct xen_memory_exchange xen_memory_exchange_t;
+DEFINE_XEN_GUEST_HANDLE(xen_memory_exchange_t);
+
+/*
+ * Returns the maximum machine frame number of mapped RAM in this system.
+ * This command always succeeds (it never returns an error code).
+ * arg == NULL.
+ */
+#define XENMEM_maximum_ram_page     2
+
+struct xen_memory_domain {
+	/* [IN] Domain information is being queried for. */
+	domid_t domid;
+};
+
+/*
+ * Returns the current or maximum memory reservation, in pages, of the
+ * specified domain (may be DOMID_SELF). Returns -ve errcode on failure.
+ * arg == addr of struct xen_memory_domain.
+ */
+#define XENMEM_current_reservation  3
+#define XENMEM_maximum_reservation  4
+
+/*
+ * Returns the maximum GFN in use by the specified domain (may be DOMID_SELF).
+ * Returns -ve errcode on failure.
+ * arg == addr of struct xen_memory_domain.
+ */
+#define XENMEM_maximum_gpfn         14
+
+/*
+ * Returns a list of MFN bases of 2MB extents comprising the machine_to_phys
+ * mapping table. Architectures which do not have a m2p table do not implement
+ * this command.
+ * arg == addr of xen_machphys_mfn_list_t.
+ */
+#define XENMEM_machphys_mfn_list    5
+struct xen_machphys_mfn_list {
+	/*
+	 * Size of the 'extent_start' array. Fewer entries will be filled if the
+	 * machphys table is smaller than max_extents * 2MB.
+	 */
+	unsigned int max_extents;
+
+	/*
+	 * Pointer to buffer to fill with list of extent starts. If there are
+	 * any large discontiguities in the machine address space, 2MB gaps in
+	 * the machphys table will be represented by an MFN base of zero.
+	 */
+	XEN_GUEST_HANDLE(xen_pfn_t) extent_start;
+
+	/*
+	 * Number of extents written to the above array. This will be smaller
+	 * than 'max_extents' if the machphys table is smaller than max_e * 2MB.
+	 */
+	unsigned int nr_extents;
+};
+typedef struct xen_machphys_mfn_list xen_machphys_mfn_list_t;
+DEFINE_XEN_GUEST_HANDLE(xen_machphys_mfn_list_t);
+
+/*
+ * For a compat caller, this is identical to XENMEM_machphys_mfn_list.
+ *
+ * For a non compat caller, this functions similarly to
+ * XENMEM_machphys_mfn_list, but returns the mfns making up the compatibility
+ * m2p table.
+ */
+#define XENMEM_machphys_compat_mfn_list     25
+
+/*
+ * Returns the location in virtual address space of the machine_to_phys
+ * mapping table. Architectures which do not have a m2p table, or which do not
+ * map it by default into guest address space, do not implement this command.
+ * arg == addr of xen_machphys_mapping_t.
+ */
+#define XENMEM_machphys_mapping     12
+struct xen_machphys_mapping {
+	xen_ulong_t v_start, v_end; /* Start and end virtual addresses.   */
+	xen_ulong_t max_mfn;        /* Maximum MFN that can be looked up. */
+};
+typedef struct xen_machphys_mapping xen_machphys_mapping_t;
+DEFINE_XEN_GUEST_HANDLE(xen_machphys_mapping_t);
+
+/* Source mapping space. */
+/* ` enum phys_map_space { */
+#define XENMAPSPACE_shared_info  0 /* shared info page */
+#define XENMAPSPACE_grant_table  1 /* grant table page */
+#define XENMAPSPACE_gmfn         2 /* GMFN */
+#define XENMAPSPACE_gmfn_range   3 /* GMFN range, XENMEM_add_to_physmap only. */
+#define XENMAPSPACE_gmfn_foreign 4 /*
+				    * GMFN from another dom,
+				    * XENMEM_add_to_physmap_batch only.
+				    */
+#define XENMAPSPACE_dev_mmio     5 /*
+				    * device mmio region
+				    * ARM only; the region is mapped in
+				    * Stage-2 using the Normal Memory
+				    * Inner/Outer Write-Back Cacheable
+				    * memory attribute.
+				    */
+/* ` } */
+
+/*
+ * Sets the GPFN at which a particular page appears in the specified guest's
+ * physical address space (translated guests only).
+ * arg == addr of xen_add_to_physmap_t.
+ */
+#define XENMEM_add_to_physmap      7
+struct xen_add_to_physmap {
+	/* Which domain to change the mapping for. */
+	domid_t domid;
+
+	/* Number of pages to go through for gmfn_range */
+	uint16_t    size;
+
+	unsigned int space; /* => enum phys_map_space */
+
+#define XENMAPIDX_grant_table_status 0x80000000U
+
+	/* Index into space being mapped. */
+	xen_ulong_t idx;
+
+	/* GPFN in domid where the source mapping page should appear. */
+	xen_pfn_t     gpfn;
+};
+typedef struct xen_add_to_physmap xen_add_to_physmap_t;
+DEFINE_XEN_GUEST_HANDLE(xen_add_to_physmap_t);
 
 /* A batched version of add_to_physmap. */
 #define XENMEM_add_to_physmap_batch 23
@@ -102,48 +299,12 @@ struct xen_add_to_physmap_batch {
 typedef struct xen_add_to_physmap_batch xen_add_to_physmap_batch_t;
 DEFINE_XEN_GUEST_HANDLE(xen_add_to_physmap_batch_t);
 
-
-#define XENMAPSPACE_shared_info		0	/* shared info page */
-#define XENMAPSPACE_grant_table		1	/* grant table page */
-#define XENMAPSPACE_gmfn		2	/* GMFN */
-
-/* GMFN range, XENMEM_add_to_physmap only.*/
-#define XENMAPSPACE_gmfn_range		3
-
-/* GMFN from another dom, XENMEM_add_to_physmap_batch only. */
-#define XENMAPSPACE_gmfn_foreign	4
-
-/*
- * Device mmio region ARM only; the region is mapped in Stage-2 using the
- * Normal Memory Inner/Outer Write-Back Cacheable memory attribute.
- */
-#define XENMAPSPACE_dev_mmio		5
-
-/*
- * Sets the GPFN at which a particular page appears in the specified guest's
- * physical address space (translated guests only).
- * arg == addr of xen_add_to_physmap_t.
- */
-#define XENMEM_add_to_physmap		7
-struct xen_add_to_physmap {
-	/* Which domain to change the mapping for. */
-	domid_t domid;
-
-	/* Number of pages to go through for gmfn_range */
-	uint16_t size;
-
-	unsigned int space; /* => enum phys_map_space */
-
-#define XENMAPIDX_grant_table_status 0x80000000
-
-	/* Index into space being mapped. */
-	xen_ulong_t idx;
-
-	/* GPFN in domid where the source mapping page should appear. */
-	xen_pfn_t gpfn;
-};
-typedef struct xen_add_to_physmap xen_add_to_physmap_t;
-DEFINE_XEN_GUEST_HANDLE(xen_add_to_physmap_t);
+#if __XEN_INTERFACE_VERSION__ < 0x00040400
+#define XENMEM_add_to_physmap_range XENMEM_add_to_physmap_batch
+#define xen_add_to_physmap_range xen_add_to_physmap_batch
+typedef struct xen_add_to_physmap_batch xen_add_to_physmap_range_t;
+DEFINE_XEN_GUEST_HANDLE(xen_add_to_physmap_range_t);
+#endif
 
 /*
  * Unmaps the page appearing at a particular GPFN from the specified guest's
@@ -161,4 +322,433 @@ struct xen_remove_from_physmap {
 typedef struct xen_remove_from_physmap xen_remove_from_physmap_t;
 DEFINE_XEN_GUEST_HANDLE(xen_remove_from_physmap_t);
 
+/*
+ * Returns the pseudo-physical memory map as it was when the domain
+ * was started (specified by XENMEM_set_memory_map).
+ * arg == addr of xen_memory_map_t.
+ */
+#define XENMEM_memory_map           9
+struct xen_memory_map {
+	/*
+	 * On call the number of entries which can be stored in buffer. On
+	 * return the number of entries which have been stored in
+	 * buffer.
+	 */
+	unsigned int nr_entries;
+
+	/*
+	 * Entries in the buffer are in the same format as returned by the
+	 * BIOS INT 0x15 EAX=0xE820 call.
+	 */
+	XEN_GUEST_HANDLE(void) buffer;
+};
+typedef struct xen_memory_map xen_memory_map_t;
+DEFINE_XEN_GUEST_HANDLE(xen_memory_map_t);
+
+/*
+ * Returns the real physical memory map. Passes the same structure as
+ * XENMEM_memory_map.
+ * Specifying buffer as NULL will return the number of entries required
+ * to store the complete memory map.
+ * arg == addr of xen_memory_map_t.
+ */
+#define XENMEM_machine_memory_map   10
+
+/*
+ * Set the pseudo-physical memory map of a domain, as returned by
+ * XENMEM_memory_map.
+ * arg == addr of xen_foreign_memory_map_t.
+ */
+#define XENMEM_set_memory_map       13
+struct xen_foreign_memory_map {
+	domid_t domid;
+	struct xen_memory_map map;
+};
+typedef struct xen_foreign_memory_map xen_foreign_memory_map_t;
+DEFINE_XEN_GUEST_HANDLE(xen_foreign_memory_map_t);
+
+#define XENMEM_set_pod_target       16
+#define XENMEM_get_pod_target       17
+struct xen_pod_target {
+	/* IN */
+	uint64_t target_pages;
+	/* OUT */
+	uint64_t tot_pages;
+	uint64_t pod_cache_pages;
+	uint64_t pod_entries;
+	/* IN */
+	domid_t domid;
+};
+typedef struct xen_pod_target xen_pod_target_t;
+
+#ifdef CONFIG_XEN_INITIAL_DOMAIN
+
+#ifndef uint64_aligned_t
+#define uint64_aligned_t uint64_t
+#endif
+
+/*
+ * Get the number of MFNs saved through memory sharing.
+ * The call never fails.
+ */
+#define XENMEM_get_sharing_freed_pages    18
+#define XENMEM_get_sharing_shared_pages   19
+
+#define XENMEM_paging_op                    20
+#define XENMEM_paging_op_nominate           0
+#define XENMEM_paging_op_evict              1
+#define XENMEM_paging_op_prep               2
+
+struct xen_mem_paging_op {
+	uint8_t     op;         /* XENMEM_paging_op_* */
+	domid_t     domain;
+
+	/* IN: (XENMEM_paging_op_prep) buffer to immediately fill page from */
+	XEN_GUEST_HANDLE_64(const_uint8) buffer;
+	/* IN:  gfn of page being operated on */
+	uint64_aligned_t    gfn;
+};
+typedef struct xen_mem_paging_op xen_mem_paging_op_t;
+DEFINE_XEN_GUEST_HANDLE(xen_mem_paging_op_t);
+
+#define XENMEM_access_op                    21
+#define XENMEM_access_op_set_access         0
+#define XENMEM_access_op_get_access         1
+/*
+ * XENMEM_access_op_enable_emulate and XENMEM_access_op_disable_emulate are
+ * currently unused, but since they have been in use please do not reuse them.
+ *
+ * #define XENMEM_access_op_enable_emulate     2
+ * #define XENMEM_access_op_disable_emulate    3
+ */
+#define XENMEM_access_op_set_access_multi   4
+
+typedef enum {
+	XENMEM_access_n,
+	XENMEM_access_r,
+	XENMEM_access_w,
+	XENMEM_access_rw,
+	XENMEM_access_x,
+	XENMEM_access_rx,
+	XENMEM_access_wx,
+	XENMEM_access_rwx,
+	/*
+	 * Page starts off as r-x, but automatically
+	 * change to r-w on a write
+	 */
+	XENMEM_access_rx2rw,
+	/*
+	 * Log access: starts off as n, automatically
+	 * goes to rwx, generating an event without
+	 * pausing the vcpu
+	 */
+	XENMEM_access_n2rwx,
+	/* Take the domain default */
+	XENMEM_access_default
+} xenmem_access_t;
+
+struct xen_mem_access_op {
+	/* XENMEM_access_op_* */
+	uint8_t op;
+	/* xenmem_access_t */
+	uint8_t access;
+	domid_t domid;
+	/*
+	 * Number of pages for set op (or size of pfn_list for
+	 * XENMEM_access_op_set_access_multi)
+	 * Ignored on setting default access and other ops
+	 */
+	uint32_t nr;
+	/*
+	 * First pfn for set op
+	 * pfn for get op
+	 * ~0ull is used to set and get the default access for pages
+	 */
+	uint64_aligned_t pfn;
+	/*
+	 * List of pfns to set access for
+	 * Used only with XENMEM_access_op_set_access_multi
+	 */
+	XEN_GUEST_HANDLE(const_uint64) pfn_list;
+	/*
+	 * Corresponding list of access settings for pfn_list
+	 * Used only with XENMEM_access_op_set_access_multi
+	 */
+	XEN_GUEST_HANDLE(const_uint8) access_list;
+};
+typedef struct xen_mem_access_op xen_mem_access_op_t;
+DEFINE_XEN_GUEST_HANDLE(xen_mem_access_op_t);
+
+#define XENMEM_sharing_op                   22
+#define XENMEM_sharing_op_nominate_gfn      0
+#define XENMEM_sharing_op_nominate_gref     1
+#define XENMEM_sharing_op_share             2
+#define XENMEM_sharing_op_debug_gfn         3
+#define XENMEM_sharing_op_debug_mfn         4
+#define XENMEM_sharing_op_debug_gref        5
+#define XENMEM_sharing_op_add_physmap       6
+#define XENMEM_sharing_op_audit             7
+#define XENMEM_sharing_op_range_share       8
+#define XENMEM_sharing_op_fork              9
+#define XENMEM_sharing_op_fork_reset        10
+
+#define XENMEM_SHARING_OP_S_HANDLE_INVALID  (-10)
+#define XENMEM_SHARING_OP_C_HANDLE_INVALID  (-9)
+
+/*
+ * The following allows sharing of grant refs. This is useful
+ * for sharing utilities sitting as "filters" in IO backends
+ * (e.g. memshr + blktap(2)). The IO backend is only exposed
+ * to grant references, and this allows sharing of the grefs
+ */
+#define XENMEM_SHARING_OP_FIELD_IS_GREF_FLAG   (xen_mk_ullong(1) << 62)
+
+#define XENMEM_SHARING_OP_FIELD_MAKE_GREF(field, val)  \
+	(field) = (XENMEM_SHARING_OP_FIELD_IS_GREF_FLAG | (val))
+#define XENMEM_SHARING_OP_FIELD_IS_GREF(field)         \
+	((field) & XENMEM_SHARING_OP_FIELD_IS_GREF_FLAG)
+#define XENMEM_SHARING_OP_FIELD_GET_GREF(field)        \
+	((field) & (~XENMEM_SHARING_OP_FIELD_IS_GREF_FLAG))
+
+struct xen_mem_sharing_op {
+	uint8_t     op;     /* XENMEM_sharing_op_* */
+	domid_t     domain;
+
+	union {
+		struct mem_sharing_op_nominate {  /* OP_NOMINATE_xxx           */
+			union {
+				uint64_aligned_t gfn;     /* IN: gfn to nominate       */
+				uint32_t      grant_ref;  /* IN: grant ref to nominate */
+			} u;
+			uint64_aligned_t  handle;     /* OUT: the handle           */
+		} nominate;
+		struct mem_sharing_op_share {     /* OP_SHARE/ADD_PHYSMAP */
+			uint64_aligned_t source_gfn;    /* IN: the gfn of the source page */
+			uint64_aligned_t source_handle; /* IN: handle to the source page */
+			uint64_aligned_t client_gfn;    /* IN: the client gfn */
+			uint64_aligned_t client_handle; /* IN: handle to the client page */
+			domid_t  client_domain; /* IN: the client domain id */
+		} share;
+		struct mem_sharing_op_range {         /* OP_RANGE_SHARE */
+			uint64_aligned_t first_gfn;      /* IN: the first gfn */
+			uint64_aligned_t last_gfn;       /* IN: the last gfn */
+			uint64_aligned_t opaque;         /* Must be set to 0 */
+			domid_t client_domain;           /* IN: the client domain id */
+			uint16_t _pad[3];                /* Must be set to 0 */
+		} range;
+		struct mem_sharing_op_debug {     /* OP_DEBUG_xxx */
+			union {
+				uint64_aligned_t gfn;      /* IN: gfn to debug          */
+				uint64_aligned_t mfn;      /* IN: mfn to debug          */
+				uint32_t gref;     /* IN: gref to debug         */
+			} u;
+		} debug;
+		struct mem_sharing_op_fork {      /* OP_FORK{,_RESET} */
+			domid_t parent_domain;        /* IN: parent's domain id */
+/* Only makes sense for short-lived forks */
+#define XENMEM_FORK_WITH_IOMMU_ALLOWED (1u << 0)
+/* Only makes sense for short-lived forks */
+#define XENMEM_FORK_BLOCK_INTERRUPTS   (1u << 1)
+#define XENMEM_FORK_RESET_STATE        (1u << 2)
+#define XENMEM_FORK_RESET_MEMORY       (1u << 3)
+			uint16_t flags;               /* IN: optional settings */
+			uint32_t pad;                 /* Must be set to 0 */
+		} fork;
+	} u;
+};
+typedef struct xen_mem_sharing_op xen_mem_sharing_op_t;
+DEFINE_XEN_GUEST_HANDLE(xen_mem_sharing_op_t);
+
+/*
+ * Attempt to stake a claim for a domain on a quantity of pages
+ * of system RAM, but _not_ assign specific pageframes.  Only
+ * arithmetic is performed so the hypercall is very fast and need
+ * not be preemptible, thus sidestepping time-of-check-time-of-use
+ * races for memory allocation.  Returns 0 if the hypervisor page
+ * allocator has atomically and successfully claimed the requested
+ * number of pages, else non-zero.
+ *
+ * Any domain may have only one active claim.  When sufficient memory
+ * has been allocated to resolve the claim, the claim silently expires.
+ * Claiming zero pages effectively resets any outstanding claim and
+ * is always successful.
+ *
+ * Note that a valid claim may be staked even after memory has been
+ * allocated for a domain.  In this case, the claim is not incremental,
+ * i.e. if the domain's total page count is 3, and a claim is staked
+ * for 10, only 7 additional pages are claimed.
+ *
+ * Caller must be privileged or the hypercall fails.
+ */
+#define XENMEM_claim_pages                  24
+
+/*
+ * XENMEM_claim_pages flags - the are no flags at this time.
+ * The zero value is appropriate.
+ */
+
+/*
+ * With some legacy devices, certain guest-physical addresses cannot safely
+ * be used for other purposes, e.g. to map guest RAM.  This hypercall
+ * enumerates those regions so the toolstack can avoid using them.
+ */
+#define XENMEM_reserved_device_memory_map   27
+struct xen_reserved_device_memory {
+	xen_pfn_t start_pfn;
+	xen_ulong_t nr_pages;
+};
+typedef struct xen_reserved_device_memory xen_reserved_device_memory_t;
+DEFINE_XEN_GUEST_HANDLE(xen_reserved_device_memory_t);
+
+struct xen_reserved_device_memory_map {
+#define XENMEM_RDM_ALL 1 /* Request all regions (ignore dev union). */
+	/* IN */
+	uint32_t flags;
+	/*
+	 * IN/OUT
+	 *
+	 * Gets set to the required number of entries when too low,
+	 * signaled by error code -ERANGE.
+	 */
+	unsigned int nr_entries;
+	/* OUT */
+	XEN_GUEST_HANDLE(xen_reserved_device_memory_t) buffer;
+	/* IN */
+	union {
+		physdev_pci_device_t pci;
+	} dev;
+};
+typedef struct xen_reserved_device_memory_map xen_reserved_device_memory_map_t;
+DEFINE_XEN_GUEST_HANDLE(xen_reserved_device_memory_map_t);
+
+#endif /* CONFIG_XEN_INITIAL_DOMAIN */
+
+/*
+ * Get the pages for a particular guest resource, so that they can be
+ * mapped directly by a tools domain.
+ */
+#define XENMEM_acquire_resource 28
+struct xen_mem_acquire_resource {
+	/* IN - The domain whose resource is to be mapped */
+	domid_t domid;
+	/* IN - the type of resource */
+	uint16_t type;
+
+#define XENMEM_resource_ioreq_server 0
+#define XENMEM_resource_grant_table 1
+#define XENMEM_resource_vmtrace_buf 2
+
+	/*
+	 * IN - a type-specific resource identifier, which must be zero
+	 *      unless stated otherwise.
+	 *
+	 * type == XENMEM_resource_ioreq_server -> id == ioreq server id
+	 * type == XENMEM_resource_grant_table -> id defined below
+	 */
+	uint32_t id;
+
+#define XENMEM_resource_grant_table_id_shared 0
+#define XENMEM_resource_grant_table_id_status 1
+
+	/*
+	 * IN/OUT
+	 *
+	 * As an IN parameter number of frames of the resource to be mapped.
+	 * This value may be updated over the course of the operation.
+	 *
+	 * When frame_list is NULL and nr_frames is 0, this is interpreted as a
+	 * request for the size of the resource, which shall be returned in the
+	 * nr_frames field.
+	 *
+	 * The size of a resource will never be zero, but a nonzero result doesn't
+	 * guarantee that a subsequent mapping request will be successful.  There
+	 * are further type/id specific constraints which may change between the
+	 * two calls.
+	 */
+	uint32_t nr_frames;
+	/*
+	 * Padding field, must be zero on input.
+	 * In a previous version this was an output field with the lowest bit
+	 * named XENMEM_rsrc_acq_caller_owned. Future versions of this interface
+	 * will not reuse this bit as an output with the field being zero on
+	 * input.
+	 */
+	uint32_t pad;
+	/*
+	 * IN - the index of the initial frame to be mapped. This parameter
+	 *      is ignored if nr_frames is 0.  This value may be updated
+	 *      over the course of the operation.
+	 */
+	uint64_t frame;
+
+#define XENMEM_resource_ioreq_server_frame_bufioreq 0
+#define XENMEM_resource_ioreq_server_frame_ioreq(n) (1 + (n))
+
+	/*
+	 * IN/OUT - If the tools domain is PV then, upon return, frame_list
+	 *          will be populated with the MFNs of the resource.
+	 *          If the tools domain is HVM then it is expected that, on
+	 *          entry, frame_list will be populated with a list of GFNs
+	 *          that will be mapped to the MFNs of the resource.
+	 *          If -EIO is returned then the frame_list has only been
+	 *          partially mapped and it is up to the caller to unmap all
+	 *          the GFNs.
+	 *          This parameter may be NULL if nr_frames is 0.  This
+	 *          value may be updated over the course of the operation.
+	 */
+	XEN_GUEST_HANDLE(xen_pfn_t) frame_list;
+};
+typedef struct xen_mem_acquire_resource xen_mem_acquire_resource_t;
+DEFINE_XEN_GUEST_HANDLE(xen_mem_acquire_resource_t);
+
+/*
+ * XENMEM_get_vnumainfo used by guest to get
+ * vNUMA topology from hypervisor.
+ */
+#define XENMEM_get_vnumainfo                26
+
+/* vNUMA node memory ranges */
+struct xen_vmemrange {
+	uint64_t start, end;
+	unsigned int flags;
+	unsigned int nid;
+};
+typedef struct xen_vmemrange xen_vmemrange_t;
+DEFINE_XEN_GUEST_HANDLE(xen_vmemrange_t);
+
+/*
+ * vNUMA topology specifies vNUMA node number, distance table,
+ * memory ranges and vcpu mapping provided for guests.
+ * XENMEM_get_vnumainfo hypercall expects to see from guest
+ * nr_vnodes, nr_vmemranges and nr_vcpus to indicate available memory.
+ * After filling guests structures, nr_vnodes, nr_vmemranges and nr_vcpus
+ * copied back to guest. Domain returns expected values of nr_vnodes,
+ * nr_vmemranges and nr_vcpus to guest if the values where incorrect.
+ */
+struct xen_vnuma_topology_info {
+	/* IN */
+	domid_t domid;
+	uint16_t pad;
+	/* IN/OUT */
+	unsigned int nr_vnodes;
+	unsigned int nr_vcpus;
+	unsigned int nr_vmemranges;
+	/* OUT */
+	union {
+		XEN_GUEST_HANDLE(uint) h;
+		uint64_t pad;
+	} vdistance;
+	union {
+		XEN_GUEST_HANDLE(uint) h;
+		uint64_t pad;
+	} vcpu_to_vnode;
+	union {
+		XEN_GUEST_HANDLE(xen_vmemrange_t) h;
+		uint64_t pad;
+	} vmemrange;
+};
+typedef struct xen_vnuma_topology_info xen_vnuma_topology_info_t;
+DEFINE_XEN_GUEST_HANDLE(xen_vnuma_topology_info_t);
+
+/* Next available subop number is 29 */
 #endif /* __XEN_PUBLIC_MEMORY_H__ */

--- a/include/zephyr/xen/public/physdev.h
+++ b/include/zephyr/xen/public/physdev.h
@@ -1,0 +1,359 @@
+/* SPDX-License-Identifier: MIT */
+
+/*
+ * Copyright (c) 2006, Keir Fraser
+ */
+
+#ifndef __XEN_PUBLIC_PHYSDEV_H__
+#define __XEN_PUBLIC_PHYSDEV_H__
+
+#include "xen.h"
+
+/*
+ * Prototype for this hypercall is:
+ *  int physdev_op(int cmd, void *args)
+ * @cmd  == PHYSDEVOP_??? (physdev operation).
+ * @args == Operation-specific extra arguments (NULL if none).
+ */
+
+/*
+ * Notify end-of-interrupt (EOI) for the specified IRQ.
+ * @arg == pointer to physdev_eoi structure.
+ */
+#define PHYSDEVOP_eoi                   12
+struct physdev_eoi {
+	/* IN */
+	uint32_t irq;
+};
+typedef struct physdev_eoi physdev_eoi_t;
+DEFINE_XEN_GUEST_HANDLE(physdev_eoi_t);
+
+/*
+ * Register a shared page for the hypervisor to indicate whether the guest
+ * must issue PHYSDEVOP_eoi. The semantics of PHYSDEVOP_eoi change slightly
+ * once the guest used this function in that the associated event channel
+ * will automatically get unmasked. The page registered is used as a bit
+ * array indexed by Xen's PIRQ value.
+ */
+#define PHYSDEVOP_pirq_eoi_gmfn_v1       17
+/*
+ * Register a shared page for the hypervisor to indicate whether the
+ * guest must issue PHYSDEVOP_eoi. This hypercall is very similar to
+ * PHYSDEVOP_pirq_eoi_gmfn_v1 but it doesn't change the semantics of
+ * PHYSDEVOP_eoi. The page registered is used as a bit array indexed by
+ * Xen's PIRQ value.
+ */
+#define PHYSDEVOP_pirq_eoi_gmfn_v2       28
+struct physdev_pirq_eoi_gmfn {
+	/* IN */
+	xen_pfn_t gmfn;
+};
+typedef struct physdev_pirq_eoi_gmfn physdev_pirq_eoi_gmfn_t;
+DEFINE_XEN_GUEST_HANDLE(physdev_pirq_eoi_gmfn_t);
+
+/*
+ * Query the status of an IRQ line.
+ * @arg == pointer to physdev_irq_status_query structure.
+ */
+#define PHYSDEVOP_irq_status_query       5
+struct physdev_irq_status_query {
+	/* IN */
+	uint32_t irq;
+	/* OUT */
+	uint32_t flags; /* XENIRQSTAT_* */
+};
+typedef struct physdev_irq_status_query physdev_irq_status_query_t;
+DEFINE_XEN_GUEST_HANDLE(physdev_irq_status_query_t);
+
+/* Need to call PHYSDEVOP_eoi when the IRQ has been serviced? */
+#define _XENIRQSTAT_needs_eoi   (0)
+#define  XENIRQSTAT_needs_eoi   (1U<<_XENIRQSTAT_needs_eoi)
+
+/* IRQ shared by multiple guests? */
+#define _XENIRQSTAT_shared      (1)
+#define  XENIRQSTAT_shared      (1U<<_XENIRQSTAT_shared)
+
+/*
+ * Set the current VCPU's I/O privilege level.
+ * @arg == pointer to physdev_set_iopl structure.
+ */
+#define PHYSDEVOP_set_iopl               6
+struct physdev_set_iopl {
+	/* IN */
+	uint32_t iopl;
+};
+typedef struct physdev_set_iopl physdev_set_iopl_t;
+DEFINE_XEN_GUEST_HANDLE(physdev_set_iopl_t);
+
+/*
+ * Set the current VCPU's I/O-port permissions bitmap.
+ * @arg == pointer to physdev_set_iobitmap structure.
+ */
+#define PHYSDEVOP_set_iobitmap           7
+struct physdev_set_iobitmap {
+	/* IN */
+#if __XEN_INTERFACE_VERSION__ >= 0x00030205
+	XEN_GUEST_HANDLE(uint8) bitmap;
+#else
+	uint8_t *bitmap;
+#endif
+	uint32_t nr_ports;
+};
+typedef struct physdev_set_iobitmap physdev_set_iobitmap_t;
+DEFINE_XEN_GUEST_HANDLE(physdev_set_iobitmap_t);
+
+/*
+ * Read or write an IO-APIC register.
+ * @arg == pointer to physdev_apic structure.
+ */
+#define PHYSDEVOP_apic_read              8
+#define PHYSDEVOP_apic_write             9
+struct physdev_apic {
+	/* IN */
+	unsigned long apic_physbase;
+	uint32_t reg;
+	/* IN or OUT */
+	uint32_t value;
+};
+typedef struct physdev_apic physdev_apic_t;
+DEFINE_XEN_GUEST_HANDLE(physdev_apic_t);
+
+/*
+ * Allocate or free a physical upcall vector for the specified IRQ line.
+ * @arg == pointer to physdev_irq structure.
+ */
+#define PHYSDEVOP_alloc_irq_vector      10
+#define PHYSDEVOP_free_irq_vector       11
+struct physdev_irq {
+	/* IN */
+	uint32_t irq;
+	/* IN or OUT */
+	uint32_t vector;
+};
+typedef struct physdev_irq physdev_irq_t;
+DEFINE_XEN_GUEST_HANDLE(physdev_irq_t);
+
+#define MAP_PIRQ_TYPE_MSI               0x0
+#define MAP_PIRQ_TYPE_GSI               0x1
+#define MAP_PIRQ_TYPE_UNKNOWN           0x2
+#define MAP_PIRQ_TYPE_MSI_SEG           0x3
+#define MAP_PIRQ_TYPE_MULTI_MSI         0x4
+
+#define PHYSDEVOP_map_pirq               13
+struct physdev_map_pirq {
+	domid_t domid;
+	/* IN */
+	int type;
+	/* IN (ignored for ..._MULTI_MSI) */
+	int index;
+	/* IN or OUT */
+	int pirq;
+	/* IN - high 16 bits hold segment for ..._MSI_SEG and ..._MULTI_MSI */
+	int bus;
+	/* IN */
+	int devfn;
+	/* IN (also OUT for ..._MULTI_MSI) */
+	int entry_nr;
+	/* IN */
+	uint64_t table_base;
+};
+typedef struct physdev_map_pirq physdev_map_pirq_t;
+DEFINE_XEN_GUEST_HANDLE(physdev_map_pirq_t);
+
+#define PHYSDEVOP_unmap_pirq             14
+struct physdev_unmap_pirq {
+	domid_t domid;
+	/* IN */
+	int pirq;
+};
+
+typedef struct physdev_unmap_pirq physdev_unmap_pirq_t;
+DEFINE_XEN_GUEST_HANDLE(physdev_unmap_pirq_t);
+
+#define PHYSDEVOP_manage_pci_add         15
+#define PHYSDEVOP_manage_pci_remove      16
+struct physdev_manage_pci {
+	/* IN */
+	uint8_t bus;
+	uint8_t devfn;
+};
+
+typedef struct physdev_manage_pci physdev_manage_pci_t;
+DEFINE_XEN_GUEST_HANDLE(physdev_manage_pci_t);
+
+#define PHYSDEVOP_restore_msi            19
+struct physdev_restore_msi {
+	/* IN */
+	uint8_t bus;
+	uint8_t devfn;
+};
+typedef struct physdev_restore_msi physdev_restore_msi_t;
+DEFINE_XEN_GUEST_HANDLE(physdev_restore_msi_t);
+
+#define PHYSDEVOP_manage_pci_add_ext     20
+struct physdev_manage_pci_ext {
+	/* IN */
+	uint8_t bus;
+	uint8_t devfn;
+	uint32_t is_extfn;
+	uint32_t is_virtfn;
+	struct {
+		uint8_t bus;
+		uint8_t devfn;
+	} physfn;
+};
+
+typedef struct physdev_manage_pci_ext physdev_manage_pci_ext_t;
+DEFINE_XEN_GUEST_HANDLE(physdev_manage_pci_ext_t);
+
+/*
+ * Argument to physdev_op_compat() hypercall. Superceded by new physdev_op()
+ * hypercall since 0x00030202.
+ */
+struct physdev_op {
+	uint32_t cmd;
+	union {
+		physdev_irq_status_query_t irq_status_query;
+		physdev_set_iopl_t         set_iopl;
+		physdev_set_iobitmap_t     set_iobitmap;
+		physdev_apic_t             apic_op;
+		physdev_irq_t              irq_op;
+	} u;
+};
+typedef struct physdev_op physdev_op_t;
+DEFINE_XEN_GUEST_HANDLE(physdev_op_t);
+
+#define PHYSDEVOP_setup_gsi    21
+struct physdev_setup_gsi {
+	int gsi;
+	/* IN */
+	uint8_t triggering;
+	/* IN */
+	uint8_t polarity;
+	/* IN */
+};
+
+typedef struct physdev_setup_gsi physdev_setup_gsi_t;
+DEFINE_XEN_GUEST_HANDLE(physdev_setup_gsi_t);
+
+/* leave PHYSDEVOP 22 free */
+
+/*
+ * type is MAP_PIRQ_TYPE_GSI or MAP_PIRQ_TYPE_MSI
+ * the hypercall returns a free pirq
+ */
+#define PHYSDEVOP_get_free_pirq    23
+struct physdev_get_free_pirq {
+	/* IN */
+	int type;
+	/* OUT */
+	uint32_t pirq;
+};
+
+typedef struct physdev_get_free_pirq physdev_get_free_pirq_t;
+DEFINE_XEN_GUEST_HANDLE(physdev_get_free_pirq_t);
+
+#define XEN_PCI_MMCFG_RESERVED         0x1
+
+#define PHYSDEVOP_pci_mmcfg_reserved    24
+struct physdev_pci_mmcfg_reserved {
+	uint64_t address;
+	uint16_t segment;
+	uint8_t start_bus;
+	uint8_t end_bus;
+	uint32_t flags;
+};
+typedef struct physdev_pci_mmcfg_reserved physdev_pci_mmcfg_reserved_t;
+DEFINE_XEN_GUEST_HANDLE(physdev_pci_mmcfg_reserved_t);
+
+#define XEN_PCI_DEV_EXTFN              0x1
+#define XEN_PCI_DEV_VIRTFN             0x2
+#define XEN_PCI_DEV_PXM                0x4
+
+#define PHYSDEVOP_pci_device_add        25
+struct physdev_pci_device_add {
+	/* IN */
+	uint16_t seg;
+	uint8_t bus;
+	uint8_t devfn;
+	uint32_t flags;
+	struct {
+		uint8_t bus;
+		uint8_t devfn;
+	} physfn;
+	/*
+	 * Optional parameters array.
+	 * First element ([0]) is PXM domain associated with the device (if
+	 * XEN_PCI_DEV_PXM is set)
+	 */
+	uint32_t optarr[XEN_FLEX_ARRAY_DIM];
+};
+typedef struct physdev_pci_device_add physdev_pci_device_add_t;
+DEFINE_XEN_GUEST_HANDLE(physdev_pci_device_add_t);
+
+#define PHYSDEVOP_pci_device_remove     26
+#define PHYSDEVOP_restore_msi_ext       27
+/*
+ * Dom0 should use these two to announce MMIO resources assigned to
+ * MSI-X capable devices won't (prepare) or may (release) change.
+ */
+#define PHYSDEVOP_prepare_msix          30
+#define PHYSDEVOP_release_msix          31
+struct physdev_pci_device {
+	/* IN */
+	uint16_t seg;
+	uint8_t bus;
+	uint8_t devfn;
+};
+typedef struct physdev_pci_device physdev_pci_device_t;
+DEFINE_XEN_GUEST_HANDLE(physdev_pci_device_t);
+
+#define PHYSDEVOP_DBGP_RESET_PREPARE    1
+#define PHYSDEVOP_DBGP_RESET_DONE       2
+
+#define PHYSDEVOP_DBGP_BUS_UNKNOWN      0
+#define PHYSDEVOP_DBGP_BUS_PCI          1
+
+#define PHYSDEVOP_dbgp_op               29
+struct physdev_dbgp_op {
+	/* IN */
+	uint8_t op;
+	uint8_t bus;
+	union {
+		physdev_pci_device_t pci;
+	} u;
+};
+typedef struct physdev_dbgp_op physdev_dbgp_op_t;
+DEFINE_XEN_GUEST_HANDLE(physdev_dbgp_op_t);
+
+/*
+ * Notify that some PIRQ-bound event channels have been unmasked.
+ * ** This command is obsolete since interface version 0x00030202 and is **
+ * ** unsupported by newer versions of Xen.                              **
+ */
+#define PHYSDEVOP_IRQ_UNMASK_NOTIFY      4
+
+#if __XEN_INTERFACE_VERSION__ < 0x00040600
+/*
+ * These all-capitals physdev operation names are superceded by the new names
+ * (defined above) since interface version 0x00030202. The guard above was
+ * added post-4.5 only though and hence shouldn't check for 0x00030202.
+ */
+#define PHYSDEVOP_IRQ_STATUS_QUERY       PHYSDEVOP_irq_status_query
+#define PHYSDEVOP_SET_IOPL               PHYSDEVOP_set_iopl
+#define PHYSDEVOP_SET_IOBITMAP           PHYSDEVOP_set_iobitmap
+#define PHYSDEVOP_APIC_READ              PHYSDEVOP_apic_read
+#define PHYSDEVOP_APIC_WRITE             PHYSDEVOP_apic_write
+#define PHYSDEVOP_ASSIGN_VECTOR          PHYSDEVOP_alloc_irq_vector
+#define PHYSDEVOP_FREE_VECTOR            PHYSDEVOP_free_irq_vector
+#define PHYSDEVOP_IRQ_NEEDS_UNMASK_NOTIFY XENIRQSTAT_needs_eoi
+#define PHYSDEVOP_IRQ_SHARED             XENIRQSTAT_shared
+#endif
+
+#if __XEN_INTERFACE_VERSION__ < 0x00040200
+#define PHYSDEVOP_pirq_eoi_gmfn PHYSDEVOP_pirq_eoi_gmfn_v1
+#else
+#define PHYSDEVOP_pirq_eoi_gmfn PHYSDEVOP_pirq_eoi_gmfn_v2
+#endif
+
+#endif /* __XEN_PUBLIC_PHYSDEV_H__ */

--- a/include/zephyr/xen/public/sysctl.h
+++ b/include/zephyr/xen/public/sysctl.h
@@ -23,6 +23,46 @@
 #define XEN_SYSCTL_INTERFACE_VERSION 0x00000015
 
 /*
+ * Read console content from Xen buffer ring.
+ */
+/* XEN_SYSCTL_readconsole */
+struct xen_sysctl_readconsole {
+	/* IN: Non-zero -> clear after reading. */
+	uint8_t clear;
+	/* IN: Non-zero -> start index specified by @index field. */
+	uint8_t incremental;
+	uint8_t pad0, pad1;
+	/*
+	 * IN:  Start index for consuming from ring buffer (if @incremental);
+	 * OUT: End index after consuming from ring buffer.
+	 */
+	uint32_t index;
+	/* IN: Virtual address to write console data. */
+	XEN_GUEST_HANDLE_64(char) buffer;
+	/* IN: Size of buffer; OUT: Bytes written to buffer. */
+	uint32_t count;
+};
+
+/* Get trace buffers machine base address */
+/* XEN_SYSCTL_tbuf_op */
+struct xen_sysctl_tbuf_op {
+	/* IN variables */
+#define XEN_SYSCTL_TBUFOP_get_info     0
+#define XEN_SYSCTL_TBUFOP_set_cpu_mask 1
+#define XEN_SYSCTL_TBUFOP_set_evt_mask 2
+#define XEN_SYSCTL_TBUFOP_set_size     3
+#define XEN_SYSCTL_TBUFOP_enable       4
+#define XEN_SYSCTL_TBUFOP_disable      5
+	uint32_t cmd;
+	/* IN/OUT variables */
+	struct xenctl_bitmap cpu_mask;
+	uint32_t             evt_mask;
+	/* OUT variables */
+	uint64_aligned_t buffer_mfn;
+	uint32_t size;  /* Also an IN variable! */
+};
+
+/*
  * Get physical information about the host machine
  */
 /* XEN_SYSCTL_physinfo */
@@ -55,6 +95,10 @@
 /* Max XEN_SYSCTL_PHYSCAP_* constant.  Used for ABI checking. */
 #define XEN_SYSCTL_PHYSCAP_MAX XEN_SYSCTL_PHYSCAP_gnttab_v2
 
+#if defined(CONFIG_ARM) || defined(CONFIG_ARM64)
+#define XEN_SYSCTL_PHYSCAP_ARM_SVE_MASK  (0x1FU)
+#endif
+
 struct xen_sysctl_physinfo {
 	uint32_t threads_per_core;
 	uint32_t cores_per_socket;
@@ -74,6 +118,40 @@ struct xen_sysctl_physinfo {
 	uint32_t hw_cap[8];
 };
 
+/*
+ * Get the ID of the current scheduler.
+ */
+/* XEN_SYSCTL_sched_id */
+struct xen_sysctl_sched_id {
+	/* OUT variable */
+	uint32_t sched_id;
+};
+
+/* Interface for controlling Xen software performance counters. */
+/* XEN_SYSCTL_perfc_op */
+/* Sub-operations: */
+#define XEN_SYSCTL_PERFCOP_reset 1   /* Reset all counters to zero. */
+#define XEN_SYSCTL_PERFCOP_query 2   /* Get perfctr information. */
+struct xen_sysctl_perfc_desc {
+	char         name[80];             /* name of perf counter */
+	uint32_t     nr_vals;              /* number of values for this counter */
+};
+typedef struct xen_sysctl_perfc_desc xen_sysctl_perfc_desc_t;
+DEFINE_XEN_GUEST_HANDLE(xen_sysctl_perfc_desc_t);
+typedef uint32_t xen_sysctl_perfc_val_t;
+DEFINE_XEN_GUEST_HANDLE(xen_sysctl_perfc_val_t);
+
+struct xen_sysctl_perfc_op {
+	/* IN variables. */
+	uint32_t       cmd;                /*  XEN_SYSCTL_PERFCOP_??? */
+	/* OUT variables. */
+	uint32_t       nr_counters;       /*  number of counters description  */
+	uint32_t       nr_vals;           /*  number of values  */
+	/* counter information (or NULL) */
+	XEN_GUEST_HANDLE_64(xen_sysctl_perfc_desc_t) desc;
+	/* counter values (or NULL) */
+	XEN_GUEST_HANDLE_64(xen_sysctl_perfc_val_t) val;
+};
 /* XEN_SYSCTL_getdomaininfolist */
 struct xen_sysctl_getdomaininfolist {
 	/* IN variables. */
@@ -84,6 +162,13 @@ struct xen_sysctl_getdomaininfolist {
 	uint32_t              num_domains;
 };
 
+/* Inject debug keys into Xen. */
+/* XEN_SYSCTL_debug_keys */
+struct xen_sysctl_debug_keys {
+	/* IN variables. */
+	XEN_GUEST_HANDLE_64(const_char) keys;
+	uint32_t nr_keys;
+};
 /* Get physical CPU information. */
 /* XEN_SYSCTL_getcpuinfo */
 struct xen_sysctl_cpuinfo {
@@ -100,6 +185,1067 @@ struct xen_sysctl_getcpuinfo {
 	/* OUT variables. */
 	uint32_t nr_cpus;
 };
+
+/* XEN_SYSCTL_availheap */
+struct xen_sysctl_availheap {
+	/* IN variables. */
+	uint32_t min_bitwidth;  /* Smallest address width (zero if don't care). */
+	uint32_t max_bitwidth;  /* Largest address width (zero if don't care). */
+	int32_t  node;          /* NUMA node of interest (-1 for all nodes). */
+	/* OUT variables. */
+	uint64_aligned_t avail_bytes;/* Bytes available in the specified region. */
+};
+
+/* XEN_SYSCTL_get_pmstat */
+struct pm_px_val {
+	uint64_aligned_t freq;        /* Px core frequency */
+	uint64_aligned_t residency;   /* Px residency time */
+	uint64_aligned_t count;       /* Px transition count */
+};
+typedef struct pm_px_val pm_px_val_t;
+DEFINE_XEN_GUEST_HANDLE(pm_px_val_t);
+
+struct pm_px_stat {
+	uint8_t total;        /* total Px states */
+	uint8_t usable;       /* usable Px states */
+	uint8_t last;         /* last Px state */
+	uint8_t cur;          /* current Px state */
+
+	XEN_GUEST_HANDLE_64(uint64) trans_pt;   /* Px transition table */
+
+	XEN_GUEST_HANDLE_64(pm_px_val_t) pt;
+};
+
+struct pm_cx_stat {
+	uint32_t nr;    /* entry nr in triggers & residencies, including C0 */
+	uint32_t last;  /* last Cx state */
+	uint64_aligned_t idle_time;                 /* idle time from boot */
+
+	XEN_GUEST_HANDLE_64(uint64) triggers;    /* Cx trigger counts */
+
+	XEN_GUEST_HANDLE_64(uint64) residencies; /* Cx residencies */
+	uint32_t nr_pc;                          /* entry nr in pc[] */
+	uint32_t nr_cc;                          /* entry nr in cc[] */
+	/*
+	 * These two arrays may (and generally will) have unused slots; slots not
+	 * having a corresponding hardware register will not be written by the
+	 * hypervisor. It is therefore up to the caller to put a suitable sentinel
+	 * into all slots before invoking the function.
+	 * Indexing is 1-biased (PC1/CC1 being at index 0).
+	 */
+	XEN_GUEST_HANDLE_64(uint64) pc;
+	XEN_GUEST_HANDLE_64(uint64) cc;
+};
+
+struct xen_sysctl_get_pmstat {
+#define PMSTAT_CATEGORY_MASK 0xf0
+#define PMSTAT_PX            0x10
+#define PMSTAT_CX            0x20
+#define PMSTAT_get_max_px    (PMSTAT_PX | 0x1)
+#define PMSTAT_get_pxstat    (PMSTAT_PX | 0x2)
+#define PMSTAT_reset_pxstat  (PMSTAT_PX | 0x3)
+#define PMSTAT_get_max_cx    (PMSTAT_CX | 0x1)
+#define PMSTAT_get_cxstat    (PMSTAT_CX | 0x2)
+#define PMSTAT_reset_cxstat  (PMSTAT_CX | 0x3)
+	uint32_t type;
+	uint32_t cpuid;
+	union {
+		struct pm_px_stat getpx;
+		struct pm_cx_stat getcx;
+		/* other struct for tx, etc */
+	} u;
+};
+
+/* XEN_SYSCTL_cpu_hotplug */
+struct xen_sysctl_cpu_hotplug {
+	/* IN variables */
+	uint32_t cpu;   /* Physical cpu. */
+
+	/* Single CPU enable/disable. */
+#define XEN_SYSCTL_CPU_HOTPLUG_ONLINE  0
+#define XEN_SYSCTL_CPU_HOTPLUG_OFFLINE 1
+
+	/*
+	 * SMT enable/disable.
+	 *
+	 * These two ops loop over all present CPUs, and either online or offline
+	 * every non-primary sibling thread (those with a thread id which is not
+	 * 0).  This behaviour is chosen to simplify the implementation.
+	 *
+	 * They are intended as a shorthand for identifying and feeding the cpu
+	 * numbers individually to HOTPLUG_{ON,OFF}LINE.
+	 *
+	 * These are not expected to be used in conjunction with debugging options
+	 * such as `maxcpus=` or when other manual configuration of offline cpus
+	 * is in use.
+	 */
+#define XEN_SYSCTL_CPU_HOTPLUG_SMT_ENABLE  2
+#define XEN_SYSCTL_CPU_HOTPLUG_SMT_DISABLE 3
+	uint32_t op;    /* hotplug opcode */
+};
+
+/*
+ * Get/set xen power management, include
+ * 1. cpufreq governors and related parameters
+ */
+/* XEN_SYSCTL_pm_op */
+struct xen_userspace {
+	uint32_t scaling_setspeed;
+};
+
+struct xen_ondemand {
+	uint32_t sampling_rate_max;
+	uint32_t sampling_rate_min;
+
+	uint32_t sampling_rate;
+	uint32_t up_threshold;
+};
+
+struct xen_cppc_para {
+	/* OUT */
+	/* activity_window supported if set */
+#define XEN_SYSCTL_CPPC_FEAT_ACT_WINDOW  (1 << 0)
+	uint32_t features; /* bit flags for features */
+	/*
+	 * See Intel SDM: HWP Performance Range and Dynamic Capabilities
+	 *
+	 * These four are 0-255 hardware-provided values.  They're "continuous,
+	 * abstract unit-less, performance" values.  Smaller numbers are slower
+	 * and larger ones are faster.
+	 */
+	uint32_t lowest;
+	uint32_t lowest_nonlinear; /* HWP: most_efficient */
+	uint32_t nominal; /* HWP: guaranteed */
+	uint32_t highest;
+	/*
+	 * See Intel SDM: IA32_HWP_REQUEST MSR (Address: 774H Logical Processor
+	 * Scope)
+	 *
+	 * These are all hints, and the processor may deviate outside of them.
+	 * Values below are 0-255.
+	 *
+	 * minimum and maximum can be set to the above hardware values to constrain
+	 * operation.  The full range 0-255 is accepted and will be clipped by
+	 * hardware.
+	 */
+	uint32_t minimum;
+	uint32_t maximum;
+	/*
+	 * An explicit performance hint, disabling hardware selection.
+	 * 0 lets the hardware decide.
+	 */
+	uint32_t desired;
+	/*
+	 * Hint to hardware for energy/performance preference.
+	 * 0:   Performance
+	 * 128: Balance (Default)
+	 * 255: Powersaving
+	 */
+	uint32_t energy_perf;
+	/*
+	 * Activity Window is a moving history window for the processor's operation
+	 * calculations, controlling responsiveness.  Measured in microseconds
+	 * encoded as:
+	 *
+	 * bits 6:0   - 7bit mantissa
+	 * bits 9:7   - 3bit base-10 exponent
+	 * btis 15:10 - Unused - must be 0
+	 */
+#define XEN_CPPC_ACT_WINDOW_MANTISSA_MASK  0x07f
+#define XEN_CPPC_ACT_WINDOW_EXPONENT_MASK  0x380
+	uint32_t activity_window;
+};
+
+/*
+ * Set CPPC values.
+ *
+ * Configure the parameters for CPPC.  Set bits in set_params control which
+ * values are applied.  If a bit is not set in set_params, the field must be
+ * zero.
+ *
+ * For HWP specifically, values must be limited to 0-255 or within
+ * XEN_SYSCTL_CPPC_ACT_WINDOW_MASK for activity window.  Set bits outside the
+ * range will be returned as -EINVAL.
+ *
+ * Activity Window may not be supported by the hardware.  In that case, the
+ * returned set_params will clear XEN_SYSCTL_CPPC_SET_ACT_WINDOW to indicate
+ * that it was not applied - though the rest of the values will be applied.
+ *
+ * There are a set of presets along with individual fields.  Presets are
+ * applied first, and then individual fields.  This allows customizing
+ * a preset without having to specify every value.
+ *
+ * The preset options values are as follows:
+ *
+ * preset      | minimum | maximum | energy_perf
+ * ------------+---------+---------+----------------
+ * powersave   | lowest  | lowest  | powersave (255)
+ * ------------+---------+---------+----------------
+ * balance     | lowest  | highest | balance (128)
+ * ------------+---------+---------+----------------
+ * performance | highest | highest | performance (0)
+ *
+ * desired and activity_window are set to 0, hardware selected.
+ */
+struct xen_set_cppc_para {
+#define XEN_SYSCTL_CPPC_SET_MINIMUM              (1U << 0)
+#define XEN_SYSCTL_CPPC_SET_MAXIMUM              (1U << 1)
+#define XEN_SYSCTL_CPPC_SET_DESIRED              (1U << 2)
+#define XEN_SYSCTL_CPPC_SET_ENERGY_PERF          (1U << 3)
+#define XEN_SYSCTL_CPPC_SET_ACT_WINDOW           (1U << 4)
+#define XEN_SYSCTL_CPPC_SET_PRESET_MASK          0xf0000000U
+#define XEN_SYSCTL_CPPC_SET_PRESET_NONE          0x00000000U
+#define XEN_SYSCTL_CPPC_SET_PRESET_BALANCE       0x10000000U
+#define XEN_SYSCTL_CPPC_SET_PRESET_POWERSAVE     0x20000000U
+#define XEN_SYSCTL_CPPC_SET_PRESET_PERFORMANCE   0x30000000U
+#define XEN_SYSCTL_CPPC_SET_PARAM_MASK \
+	(XEN_SYSCTL_CPPC_SET_PRESET_MASK | \
+	 XEN_SYSCTL_CPPC_SET_MINIMUM     | \
+	 XEN_SYSCTL_CPPC_SET_MAXIMUM     | \
+	 XEN_SYSCTL_CPPC_SET_DESIRED     | \
+	 XEN_SYSCTL_CPPC_SET_ENERGY_PERF | \
+	 XEN_SYSCTL_CPPC_SET_ACT_WINDOW)
+	/* IN/OUT */
+	uint32_t set_params; /* bitflags for valid values */
+	/* See comments in struct xen_cppc_para. */
+	/* IN */
+	uint32_t minimum;
+	uint32_t maximum;
+	uint32_t desired;
+	uint32_t energy_perf;
+#define XEN_SYSCTL_CPPC_ACT_WINDOW_MASK (XEN_CPPC_ACT_WINDOW_MANTISSA_MASK | \
+					 XEN_CPPC_ACT_WINDOW_EXPONENT_MASK)
+	uint32_t activity_window;
+};
+
+#define XEN_HWP_DRIVER_NAME "hwp"
+
+/*
+ * cpufreq para name of this structure named
+ * same as sysfs file name of native linux
+ */
+#define CPUFREQ_NAME_LEN 16
+struct xen_get_cpufreq_para {
+	/* IN/OUT variable */
+	uint32_t cpu_num;
+	uint32_t freq_num;
+	uint32_t gov_num;
+
+	/* for all governors */
+	/* OUT variable */
+	XEN_GUEST_HANDLE_64(uint32) affected_cpus;
+	XEN_GUEST_HANDLE_64(uint32) scaling_available_frequencies;
+	XEN_GUEST_HANDLE_64(char)   scaling_available_governors;
+	char scaling_driver[CPUFREQ_NAME_LEN];
+
+	uint32_t cpuinfo_cur_freq;
+	uint32_t cpuinfo_max_freq;
+	uint32_t cpuinfo_min_freq;
+	union {
+		struct {
+			uint32_t scaling_cur_freq;
+
+			char scaling_governor[CPUFREQ_NAME_LEN];
+			uint32_t scaling_max_freq;
+			uint32_t scaling_min_freq;
+
+			/* for specific governor */
+			union {
+				struct  xen_userspace userspace;
+				struct  xen_ondemand ondemand;
+			} u;
+		} s;
+		struct xen_cppc_para cppc_para;
+	} u;
+
+	int32_t turbo_enabled;
+};
+
+struct xen_set_cpufreq_gov {
+	char scaling_governor[CPUFREQ_NAME_LEN];
+};
+
+struct xen_set_cpufreq_para {
+#define SCALING_MAX_FREQ           1
+#define SCALING_MIN_FREQ           2
+#define SCALING_SETSPEED           3
+#define SAMPLING_RATE              4
+#define UP_THRESHOLD               5
+
+	uint32_t ctrl_type;
+	uint32_t ctrl_value;
+};
+
+struct xen_sysctl_pm_op {
+#define PM_PARA_CATEGORY_MASK      0xf0
+#define CPUFREQ_PARA               0x10
+
+/* cpufreq command type */
+#define GET_CPUFREQ_PARA           (CPUFREQ_PARA | 0x01)
+#define SET_CPUFREQ_GOV            (CPUFREQ_PARA | 0x02)
+#define SET_CPUFREQ_PARA           (CPUFREQ_PARA | 0x03)
+#define GET_CPUFREQ_AVGFREQ        (CPUFREQ_PARA | 0x04)
+#define SET_CPUFREQ_CPPC           (CPUFREQ_PARA | 0x05)
+
+/* set/reset scheduler power saving option */
+#define XEN_SYSCTL_pm_op_set_sched_opt_smt    0x21
+
+/*
+ * cpuidle max C-state and max C-sub-state access command:
+ * Set cpuid to 0 for max C-state.
+ * Set cpuid to 1 for max C-sub-state.
+ */
+#define XEN_SYSCTL_pm_op_get_max_cstate       0x22
+#define XEN_SYSCTL_pm_op_set_max_cstate       0x23
+
+/* set scheduler migration cost value */
+#define XEN_SYSCTL_pm_op_set_vcpu_migration_delay   0x24
+#define XEN_SYSCTL_pm_op_get_vcpu_migration_delay   0x25
+
+/* enable/disable turbo mode when in dbs governor */
+#define XEN_SYSCTL_pm_op_enable_turbo               0x26
+#define XEN_SYSCTL_pm_op_disable_turbo              0x27
+
+	uint32_t cmd;
+	uint32_t cpuid;
+	union {
+		struct xen_get_cpufreq_para get_para;
+		struct xen_set_cpufreq_gov  set_gov;
+		struct xen_set_cpufreq_para set_para;
+		struct xen_set_cppc_para    set_cppc;
+		uint64_aligned_t get_avgfreq;
+		uint32_t                    set_sched_opt_smt;
+#define XEN_SYSCTL_CX_UNLIMITED 0xffffffffU
+		uint32_t                    get_max_cstate;
+		uint32_t                    set_max_cstate;
+	} u;
+};
+
+/* XEN_SYSCTL_page_offline_op */
+struct xen_sysctl_page_offline_op {
+	/* IN: range of page to be offlined */
+#define sysctl_page_offline     1
+#define sysctl_page_online      2
+#define sysctl_query_page_offline  3
+	uint32_t cmd;
+	uint32_t start;
+	uint32_t end;
+	/* OUT: result of page offline request */
+	/*
+	 * bit 0~15: result flags
+	 * bit 16~31: owner
+	 */
+	XEN_GUEST_HANDLE(uint32) status;
+};
+
+#define PG_OFFLINE_STATUS_MASK    (0xFFUL)
+
+/* The result is invalid, i.e. HV does not handle it */
+#define PG_OFFLINE_INVALID   (0x1UL << 0)
+
+#define PG_OFFLINE_OFFLINED  (0x1UL << 1)
+#define PG_OFFLINE_PENDING   (0x1UL << 2)
+#define PG_OFFLINE_FAILED    (0x1UL << 3)
+#define PG_OFFLINE_AGAIN     (0x1UL << 4)
+
+#define PG_ONLINE_FAILED     PG_OFFLINE_FAILED
+#define PG_ONLINE_ONLINED    PG_OFFLINE_OFFLINED
+
+#define PG_OFFLINE_STATUS_OFFLINED              (0x1UL << 1)
+#define PG_OFFLINE_STATUS_ONLINE                (0x1UL << 2)
+#define PG_OFFLINE_STATUS_OFFLINE_PENDING       (0x1UL << 3)
+#define PG_OFFLINE_STATUS_BROKEN                (0x1UL << 4)
+
+#define PG_OFFLINE_MISC_MASK    (0xFFUL << 4)
+
+/* valid when PG_OFFLINE_FAILED or PG_OFFLINE_PENDING */
+#define PG_OFFLINE_XENPAGE   (0x1UL << 8)
+#define PG_OFFLINE_DOM0PAGE  (0x1UL << 9)
+#define PG_OFFLINE_ANONYMOUS (0x1UL << 10)
+#define PG_OFFLINE_NOT_CONV_RAM   (0x1UL << 11)
+#define PG_OFFLINE_OWNED     (0x1UL << 12)
+
+#define PG_OFFLINE_BROKEN    (0x1UL << 13)
+#define PG_ONLINE_BROKEN     PG_OFFLINE_BROKEN
+
+#define PG_OFFLINE_OWNER_SHIFT 16
+
+/* XEN_SYSCTL_lockprof_op */
+/* Sub-operations: */
+#define XEN_SYSCTL_LOCKPROF_reset 1   /* Reset all profile data to zero. */
+#define XEN_SYSCTL_LOCKPROF_query 2   /* Get lock profile information. */
+/* Record-type: */
+#define LOCKPROF_TYPE_GLOBAL      0   /* global lock, idx meaningless */
+#define LOCKPROF_TYPE_PERDOM      1   /* per-domain lock, idx is domid */
+#define LOCKPROF_TYPE_N           2   /* number of types */
+struct xen_sysctl_lockprof_data {
+	char     name[40];     /* lock name (may include up to 2 %d specifiers) */
+	int32_t  type;         /* LOCKPROF_TYPE_??? */
+	int32_t  idx;          /* index (e.g. domain id) */
+	uint64_aligned_t lock_cnt;     /* # of locking succeeded */
+	uint64_aligned_t block_cnt;    /* # of wait for lock */
+	uint64_aligned_t lock_time;    /* nsecs lock held */
+	uint64_aligned_t block_time;   /* nsecs waited for lock */
+};
+typedef struct xen_sysctl_lockprof_data xen_sysctl_lockprof_data_t;
+DEFINE_XEN_GUEST_HANDLE(xen_sysctl_lockprof_data_t);
+
+struct xen_sysctl_lockprof_op {
+	/* IN variables. */
+	uint32_t       cmd;               /* XEN_SYSCTL_LOCKPROF_??? */
+	uint32_t       max_elem;          /* size of output buffer */
+	/* OUT variables (query only). */
+	uint32_t       nr_elem;           /* number of elements available */
+	uint64_aligned_t time;            /* nsecs of profile measurement */
+	/* profile information (or NULL) */
+	XEN_GUEST_HANDLE_64(xen_sysctl_lockprof_data_t) data;
+};
+
+/* XEN_SYSCTL_cputopoinfo */
+#define XEN_INVALID_CORE_ID     (~0U)
+#define XEN_INVALID_SOCKET_ID   (~0U)
+#define XEN_INVALID_NODE_ID     (~0U)
+
+struct xen_sysctl_cputopo {
+	uint32_t core;
+	uint32_t socket;
+	uint32_t node;
+};
+typedef struct xen_sysctl_cputopo xen_sysctl_cputopo_t;
+DEFINE_XEN_GUEST_HANDLE(xen_sysctl_cputopo_t);
+
+/*
+ * IN:
+ *  - a NULL 'cputopo' handle is a request for maximun 'num_cpus'.
+ *  - otherwise it's the number of entries in 'cputopo'
+ *
+ * OUT:
+ *  - If 'num_cpus' is less than the number Xen wants to write but the handle
+ *    handle is not a NULL one, partial data gets returned and 'num_cpus' gets
+ *    updated to reflect the intended number.
+ *  - Otherwise, 'num_cpus' shall indicate the number of entries written, which
+ *    may be less than the input value.
+ */
+struct xen_sysctl_cputopoinfo {
+	uint32_t num_cpus;
+
+	XEN_GUEST_HANDLE_64(xen_sysctl_cputopo_t) cputopo;
+};
+
+/* XEN_SYSCTL_numainfo */
+#define XEN_INVALID_MEM_SZ     (~0U)
+#define XEN_INVALID_NODE_DIST  (~0U)
+
+struct xen_sysctl_meminfo {
+	uint64_t memsize;
+	uint64_t memfree;
+};
+typedef struct xen_sysctl_meminfo xen_sysctl_meminfo_t;
+DEFINE_XEN_GUEST_HANDLE(xen_sysctl_meminfo_t);
+
+/*
+ * IN:
+ *  - Both 'meminfo' and 'distance' handles being null is a request
+ *    for maximum value of 'num_nodes'.
+ *  - Otherwise it's the number of entries in 'meminfo' and square root
+ *    of number of entries in 'distance' (when corresponding handle is
+ *    non-null)
+ *
+ * OUT:
+ *  - If 'num_nodes' is less than the number Xen wants to write but either
+ *    handle is not a NULL one, partial data gets returned and 'num_nodes'
+ *    gets updated to reflect the intended number.
+ *  - Otherwise, 'num_nodes' shall indicate the number of entries written, which
+ *    may be less than the input value.
+ */
+
+struct xen_sysctl_numainfo {
+	uint32_t num_nodes;
+
+	XEN_GUEST_HANDLE_64(xen_sysctl_meminfo_t) meminfo;
+
+	/*
+	 * Distance between nodes 'i' and 'j' is stored in index 'i*N + j',
+	 * where N is the number of nodes that will be returned in 'num_nodes'
+	 * (i.e. not 'num_nodes' provided by the caller)
+	 */
+	XEN_GUEST_HANDLE_64(uint32) distance;
+};
+
+/* XEN_SYSCTL_cpupool_op */
+#define XEN_SYSCTL_CPUPOOL_OP_CREATE                1  /* C */
+#define XEN_SYSCTL_CPUPOOL_OP_DESTROY               2  /* D */
+#define XEN_SYSCTL_CPUPOOL_OP_INFO                  3  /* I */
+#define XEN_SYSCTL_CPUPOOL_OP_ADDCPU                4  /* A */
+#define XEN_SYSCTL_CPUPOOL_OP_RMCPU                 5  /* R */
+#define XEN_SYSCTL_CPUPOOL_OP_MOVEDOMAIN            6  /* M */
+#define XEN_SYSCTL_CPUPOOL_OP_FREEINFO              7  /* F */
+#define XEN_SYSCTL_CPUPOOL_PAR_ANY     0xFFFFFFFFU
+struct xen_sysctl_cpupool_op {
+	uint32_t op;          /* IN */
+	uint32_t cpupool_id;  /* IN: CDIARM OUT: CI */
+	uint32_t sched_id;    /* IN: C      OUT: I  */
+	uint32_t domid;       /* IN: M              */
+	uint32_t cpu;         /* IN: AR             */
+	uint32_t n_dom;       /*            OUT: I  */
+	struct xenctl_bitmap cpumap; /*     OUT: IF */
+};
+
+/*
+ * Error return values of cpupool operations:
+ *
+ * -EADDRINUSE:
+ *  XEN_SYSCTL_CPUPOOL_OP_RMCPU: A vcpu is temporarily pinned to the cpu
+ *    which is to be removed from a cpupool.
+ * -EADDRNOTAVAIL:
+ *  XEN_SYSCTL_CPUPOOL_OP_ADDCPU, XEN_SYSCTL_CPUPOOL_OP_RMCPU: A previous
+ *    request to remove a cpu from a cpupool was terminated with -EAGAIN
+ *    and has not been retried using the same parameters.
+ * -EAGAIN:
+ *  XEN_SYSCTL_CPUPOOL_OP_RMCPU: The cpu can't be removed from the cpupool
+ *    as it is active in the hypervisor. A retry will succeed soon.
+ * -EBUSY:
+ *  XEN_SYSCTL_CPUPOOL_OP_DESTROY, XEN_SYSCTL_CPUPOOL_OP_RMCPU: A cpupool
+ *    can't be destroyed or the last cpu can't be removed as there is still
+ *    a running domain in that cpupool.
+ * -EEXIST:
+ *  XEN_SYSCTL_CPUPOOL_OP_CREATE: A cpupool_id was specified and is already
+ *    existing.
+ * -EINVAL:
+ *  XEN_SYSCTL_CPUPOOL_OP_ADDCPU, XEN_SYSCTL_CPUPOOL_OP_RMCPU: An illegal
+ *    cpu was specified (cpu does not exist).
+ *  XEN_SYSCTL_CPUPOOL_OP_MOVEDOMAIN: An illegal domain was specified
+ *    (domain id illegal or not suitable for operation).
+ * -ENODEV:
+ *  XEN_SYSCTL_CPUPOOL_OP_ADDCPU, XEN_SYSCTL_CPUPOOL_OP_RMCPU: The specified
+ *    cpu is either not free (add) or not member of the specified cpupool
+ *    (remove).
+ * -ENOENT:
+ *  all: The cpupool with the specified cpupool_id doesn't exist.
+ *
+ * Some common error return values like -ENOMEM and -EFAULT are possible for
+ * all the operations.
+ */
+
+#define ARINC653_MAX_DOMAINS_PER_SCHEDULE   64
+/*
+ * This structure is used to pass a new ARINC653 schedule from a
+ * privileged domain (ie dom0) to Xen.
+ */
+struct xen_sysctl_arinc653_schedule {
+	/*
+	 * major_frame holds the time for the new schedule's major frame
+	 * in nanoseconds.
+	 */
+	uint64_aligned_t     major_frame;
+	/*
+	 * num_sched_entries holds how many of the entries in the
+	 * sched_entries[] array are valid.
+	 */
+	uint8_t     num_sched_entries;
+	/* The sched_entries array holds the actual schedule entries. */
+	struct {
+		/* dom_handle must match a domain's UUID */
+		xen_domain_handle_t dom_handle;
+		/*
+		 * If a domain has multiple VCPUs, vcpu_id specifies which one
+		 * this schedule entry applies to. It should be set to 0 if
+		 * there is only one VCPU for the domain.
+		 */
+		uint32_t vcpu_id;
+		/*
+		 * runtime specifies the amount of time that should be allocated
+		 * to this VCPU per major frame. It is specified in nanoseconds
+		 */
+		uint64_aligned_t runtime;
+	} sched_entries[ARINC653_MAX_DOMAINS_PER_SCHEDULE];
+};
+typedef struct xen_sysctl_arinc653_schedule xen_sysctl_arinc653_schedule_t;
+DEFINE_XEN_GUEST_HANDLE(xen_sysctl_arinc653_schedule_t);
+
+/*
+ * Valid range for context switch rate limit (in microseconds).
+ * Applicable to Credit and Credit2 schedulers.
+ */
+#define XEN_SYSCTL_SCHED_RATELIMIT_MAX 500000
+#define XEN_SYSCTL_SCHED_RATELIMIT_MIN 100
+
+struct xen_sysctl_credit_schedule {
+	/* Length of timeslice in milliseconds */
+#define XEN_SYSCTL_CSCHED_TSLICE_MAX 1000
+#define XEN_SYSCTL_CSCHED_TSLICE_MIN 1
+	uint32_t tslice_ms;
+	uint32_t ratelimit_us;
+	/*
+	 * How long we consider a vCPU to be cache-hot on the
+	 * CPU where it has run (max 100ms, in microseconds)
+	 */
+#define XEN_SYSCTL_CSCHED_MGR_DLY_MAX_US (100 * 1000)
+	uint32_t vcpu_migr_delay_us;
+};
+
+struct xen_sysctl_credit2_schedule {
+	uint32_t ratelimit_us;
+};
+
+/* XEN_SYSCTL_scheduler_op */
+/* Set or get info? */
+#define XEN_SYSCTL_SCHEDOP_putinfo 0
+#define XEN_SYSCTL_SCHEDOP_getinfo 1
+struct xen_sysctl_scheduler_op {
+	uint32_t cpupool_id; /* Cpupool whose scheduler is to be targeted. */
+	uint32_t sched_id;   /* XEN_SCHEDULER_* (domctl.h) */
+	uint32_t cmd;        /* XEN_SYSCTL_SCHEDOP_* */
+	union {
+		struct xen_sysctl_sched_arinc653 {
+			XEN_GUEST_HANDLE_64(xen_sysctl_arinc653_schedule_t) schedule;
+		} sched_arinc653;
+		struct xen_sysctl_credit_schedule sched_credit;
+		struct xen_sysctl_credit2_schedule sched_credit2;
+	} u;
+};
+
+/*
+ * Output format of gcov data:
+ *
+ * XEN_GCOV_FORMAT_MAGIC XEN_GCOV_RECORD ... XEN_GCOV_RECORD
+ *
+ * That is, one magic number followed by 0 or more record.
+ *
+ * The magic number is stored as an uint32_t field.
+ *
+ * The record is packed and variable in length. It has the form:
+ *
+ *  filename: a NULL terminated path name extracted from gcov, used to
+ *            create the name of gcda file.
+ *  size:     a uint32_t field indicating the size of the payload, the
+ *            unit is byte.
+ *  payload:  the actual payload, length is `size' bytes.
+ *
+ * Userspace tool will split the record to different files.
+ */
+
+#define XEN_GCOV_FORMAT_MAGIC    0x58434f56 /* XCOV */
+
+/*
+ * Output format of LLVM coverage data is just a raw stream, as would be
+ * written by the compiler_rt run time library into a .profraw file. There
+ * are no special Xen tags or delimiters because none are needed.
+ */
+
+#define XEN_SYSCTL_COVERAGE_get_size 0 /* Get total size of output data */
+#define XEN_SYSCTL_COVERAGE_read     1 /* Read output data */
+#define XEN_SYSCTL_COVERAGE_reset    2 /* Reset all counters */
+
+struct xen_sysctl_coverage_op {
+	uint32_t cmd;
+	uint32_t size; /* IN/OUT: size of the buffer  */
+
+	XEN_GUEST_HANDLE_64(char) buffer; /* OUT */
+};
+
+#define XEN_SYSCTL_PSR_CMT_get_total_rmid            0
+#define XEN_SYSCTL_PSR_CMT_get_l3_upscaling_factor   1
+/* The L3 cache size is returned in KB unit */
+#define XEN_SYSCTL_PSR_CMT_get_l3_cache_size         2
+#define XEN_SYSCTL_PSR_CMT_enabled                   3
+#define XEN_SYSCTL_PSR_CMT_get_l3_event_mask         4
+struct xen_sysctl_psr_cmt_op {
+	uint32_t cmd;       /* IN: XEN_SYSCTL_PSR_CMT_* */
+	uint32_t flags;     /* padding variable, may be extended for future use */
+	union {
+		uint64_t data;  /* OUT */
+		struct {
+			uint32_t cpu;   /* IN */
+			uint32_t rsvd;
+		} l3_cache;
+	} u;
+};
+
+/* XEN_SYSCTL_pcitopoinfo */
+#define XEN_INVALID_DEV (XEN_INVALID_NODE_ID - 1)
+struct xen_sysctl_pcitopoinfo {
+	/*
+	 * IN: Number of elements in 'devs' and 'nodes' arrays.
+	 * OUT: Number of processed elements of those arrays.
+	 */
+	uint32_t num_devs;
+
+	/* IN: list of devices for which node IDs are requested. */
+	XEN_GUEST_HANDLE_64(physdev_pci_device_t) devs;
+
+	/*
+	 * OUT: node identifier for each device.
+	 * If information for a particular device is not available then
+	 * corresponding entry will be set to XEN_INVALID_NODE_ID. If
+	 * device is not known to the hypervisor then XEN_INVALID_DEV
+	 * will be provided.
+	 */
+	XEN_GUEST_HANDLE_64(uint32) nodes;
+};
+
+#define XEN_SYSCTL_PSR_get_l3_info               0
+#define XEN_SYSCTL_PSR_get_l2_info               1
+#define XEN_SYSCTL_PSR_get_mba_info              2
+struct xen_sysctl_psr_alloc {
+	uint32_t cmd;       /* IN: XEN_SYSCTL_PSR_* */
+	uint32_t target;    /* IN */
+	union {
+		struct {
+			uint32_t cbm_len;   /* OUT: CBM length */
+			uint32_t cos_max;   /* OUT: Maximum COS */
+#define XEN_SYSCTL_PSR_CAT_L3_CDP       (1u << 0)
+			uint32_t flags;     /* OUT: CAT flags */
+		} cat_info;
+
+		struct {
+			uint32_t thrtl_max; /* OUT: Maximum throttle */
+			uint32_t cos_max;   /* OUT: Maximum COS */
+#define XEN_SYSCTL_PSR_MBA_LINEAR      (1u << 0)
+			uint32_t flags;     /* OUT: MBA flags */
+		} mba_info;
+	} u;
+};
+
+/*
+ * XEN_SYSCTL_get_cpu_levelling_caps (x86 specific)
+ *
+ * Return hardware capabilities concerning masking or faulting of the cpuid
+ * instruction for PV guests.
+ */
+struct xen_sysctl_cpu_levelling_caps {
+#define XEN_SYSCTL_CPU_LEVELCAP_faulting    (1ul <<  0) /* CPUID faulting    */
+#define XEN_SYSCTL_CPU_LEVELCAP_ecx         (1ul <<  1) /* 0x00000001.ecx    */
+#define XEN_SYSCTL_CPU_LEVELCAP_edx         (1ul <<  2) /* 0x00000001.edx    */
+#define XEN_SYSCTL_CPU_LEVELCAP_extd_ecx    (1ul <<  3) /* 0x80000001.ecx    */
+#define XEN_SYSCTL_CPU_LEVELCAP_extd_edx    (1ul <<  4) /* 0x80000001.edx    */
+#define XEN_SYSCTL_CPU_LEVELCAP_xsave_eax   (1ul <<  5) /* 0x0000000D:1.eax  */
+#define XEN_SYSCTL_CPU_LEVELCAP_thermal_ecx (1ul <<  6) /* 0x00000006.ecx    */
+#define XEN_SYSCTL_CPU_LEVELCAP_l7s0_eax    (1ul <<  7) /* 0x00000007:0.eax  */
+#define XEN_SYSCTL_CPU_LEVELCAP_l7s0_ebx    (1ul <<  8) /* 0x00000007:0.ebx  */
+	uint32_t caps;
+};
+
+/*
+ * XEN_SYSCTL_get_cpu_featureset (x86 specific)
+ *
+ * Return information about featuresets available on this host.
+ *  -  Raw: The real cpuid values.
+ *  - Host: The values Xen is using, (after command line overrides, etc).
+ *  -   PV: Maximum set of features which can be given to a PV guest.
+ *  -  HVM: Maximum set of features which can be given to a HVM guest.
+ * May fail with -EOPNOTSUPP if querying for PV or HVM data when support is
+ * compiled out of Xen.
+ */
+struct xen_sysctl_cpu_featureset {
+#define XEN_SYSCTL_cpu_featureset_raw      0
+#define XEN_SYSCTL_cpu_featureset_host     1
+#define XEN_SYSCTL_cpu_featureset_pv       2
+#define XEN_SYSCTL_cpu_featureset_hvm      3
+#define XEN_SYSCTL_cpu_featureset_pv_max   4
+#define XEN_SYSCTL_cpu_featureset_hvm_max  5
+	uint32_t index;       /* IN: Which featureset to query? */
+	uint32_t nr_features; /*
+			       * IN/OUT: Number of entries in/written to
+			       * 'features', or the maximum number of features if
+			       * the guest handle is NULL.  NB. All featuresets
+			       * come from the same numberspace, so have the same
+			       * maximum length.
+			       */
+	XEN_GUEST_HANDLE_64(uint32) features; /* OUT: */
+};
+
+/*
+ * XEN_SYSCTL_LIVEPATCH_op
+ *
+ * Refer to the docs/unstable/misc/livepatch.markdown
+ * for the design details of this hypercall.
+ *
+ * There are four sub-ops:
+ *  XEN_SYSCTL_LIVEPATCH_UPLOAD (0)
+ *  XEN_SYSCTL_LIVEPATCH_GET (1)
+ *  XEN_SYSCTL_LIVEPATCH_LIST (2)
+ *  XEN_SYSCTL_LIVEPATCH_ACTION (3)
+ *
+ * The normal sequence of sub-ops is to:
+ *  1) XEN_SYSCTL_LIVEPATCH_UPLOAD to upload the payload. If errors STOP.
+ *  2) XEN_SYSCTL_LIVEPATCH_GET to check the `->rc`. If -XEN_EAGAIN spin.
+ *     If zero go to next step.
+ *  3) XEN_SYSCTL_LIVEPATCH_ACTION with LIVEPATCH_ACTION_APPLY to apply the patch.
+ *  4) XEN_SYSCTL_LIVEPATCH_GET to check the `->rc`. If in -XEN_EAGAIN spin.
+ *     If zero exit with success.
+ */
+
+#define LIVEPATCH_PAYLOAD_VERSION 2
+/*
+ * .livepatch.funcs structure layout defined in the `Payload format`
+ * section in the Live Patch design document.
+ *
+ * We guard this with __XEN__ as toolstacks SHOULD not use it.
+ */
+#ifdef __XEN__
+#define LIVEPATCH_OPAQUE_SIZE 31
+
+struct livepatch_expectation {
+	uint8_t enabled : 1;
+	uint8_t len : 5;        /*
+				 * Length of data up to LIVEPATCH_OPAQUE_SIZE
+				 * (5 bits is enough for now)
+				 */
+	uint8_t rsv : 2;        /* Reserved. Zero value */
+	uint8_t data[LIVEPATCH_OPAQUE_SIZE];	/*
+						 * Same size as opaque[] buffer of
+						 * struct livepatch_func. This is the
+						 * max number of bytes to be patched
+						 */
+};
+typedef struct livepatch_expectation livepatch_expectation_t;
+
+typedef enum livepatch_func_state {
+	LIVEPATCH_FUNC_NOT_APPLIED,
+	LIVEPATCH_FUNC_APPLIED
+} livepatch_func_state_t;
+
+struct livepatch_func {
+	const char *name;       /* Name of function to be patched. */
+	void *new_addr;
+	void *old_addr;
+	uint32_t new_size;
+	uint32_t old_size;
+	uint8_t version;        /* MUST be LIVEPATCH_PAYLOAD_VERSION. */
+	uint8_t _pad[39];
+	livepatch_expectation_t expect;
+};
+typedef struct livepatch_func livepatch_func_t;
+#endif
+
+/*
+ * Structure describing an ELF payload. Uniquely identifies the
+ * payload. Should be human readable.
+ * Recommended length is upto XEN_LIVEPATCH_NAME_SIZE.
+ * Includes the NUL terminator.
+ */
+#define XEN_LIVEPATCH_NAME_SIZE 128
+struct xen_livepatch_name {
+	XEN_GUEST_HANDLE_64(char) name;         /* IN: pointer to name. */
+	uint16_t size;                          /*
+						 * IN: size of name. May be upto
+						 * XEN_LIVEPATCH_NAME_SIZE.
+						 */
+	uint16_t pad[3];                        /* IN: MUST be zero. */
+};
+
+/*
+ * Upload a payload to the hypervisor. The payload is verified
+ * against basic checks and if there are any issues the proper return code
+ * will be returned. The payload is not applied at this time - that is
+ * controlled by XEN_SYSCTL_LIVEPATCH_ACTION.
+ *
+ * The return value is zero if the payload was successfully uploaded.
+ * Otherwise an EXX return value is provided. Duplicate `name` are not
+ * supported.
+ *
+ * The payload at this point is verified against basic checks.
+ *
+ * The `payload` is the ELF payload as mentioned in the `Payload format`
+ * section in the Live Patch design document.
+ */
+#define XEN_SYSCTL_LIVEPATCH_UPLOAD 0
+struct xen_sysctl_livepatch_upload {
+	struct xen_livepatch_name name;         /* IN, name of the patch. */
+	uint64_t size;                          /* IN, size of the ELF file. */
+
+	XEN_GUEST_HANDLE_64(uint8) payload;     /* IN, the ELF file. */
+};
+
+/*
+ * Retrieve an status of an specific payload.
+ *
+ * Upon completion the `struct xen_livepatch_status` is updated.
+ *
+ * The return value is zero on success and XEN_EXX on failure. This operation
+ * is synchronous and does not require preemption.
+ */
+#define XEN_SYSCTL_LIVEPATCH_GET 1
+
+struct xen_livepatch_status {
+#define LIVEPATCH_STATE_CHECKED      1
+#define LIVEPATCH_STATE_APPLIED      2
+	uint32_t state;                /* OUT: LIVEPATCH_STATE_*. */
+	int32_t rc;                    /* OUT: 0 if no error, otherwise -XEN_EXX. */
+};
+typedef struct xen_livepatch_status xen_livepatch_status_t;
+DEFINE_XEN_GUEST_HANDLE(xen_livepatch_status_t);
+
+struct xen_sysctl_livepatch_get {
+	struct xen_livepatch_name name;         /* IN, name of the payload. */
+	struct xen_livepatch_status status;     /* IN/OUT, state of it. */
+};
+
+/*
+ * Retrieve an array of abbreviated status, names and metadata of payloads that
+ * are loaded in the hypervisor.
+ *
+ * If the hypercall returns an positive number, it is the number (up to `nr`)
+ * of the payloads returned, along with `nr` updated with the number of remaining
+ * payloads, `version` updated (it may be the same across hypercalls. If it varies
+ * the data is stale and further calls could fail), `name_total_size` and
+ * `metadata_total_size` containing total sizes of transferred data for both the
+ * arrays.
+ * The `status`, `name`, `len`, `metadata` and `metadata_len` are updated at their
+ * designed index value (`idx`) with the returned value of data.
+ *
+ * If the hypercall returns E2BIG the `nr` is too big and should be
+ * lowered. The upper limit of `nr` is left to the implementation.
+ *
+ * Note that due to the asynchronous nature of hypercalls the domain might have
+ * added or removed the number of payloads making this information stale. It is
+ * the responsibility of the toolstack to use the `version` field to check
+ * between each invocation. if the version differs it should discard the stale
+ * data and start from scratch. It is OK for the toolstack to use the new
+ * `version` field.
+ */
+#define XEN_SYSCTL_LIVEPATCH_LIST 2
+struct xen_sysctl_livepatch_list {
+	uint32_t version;                       /*
+						 * OUT: Hypervisor stamps value.
+						 * If varies between calls, we are
+						 * getting stale data.
+						 */
+	uint32_t idx;                           /* IN: Index into hypervisor list. */
+	uint32_t nr;                            /*
+						 * IN: How many status, name, and len
+						 * should fill out. Can be zero to get
+						 * amount of payloads and version.
+						 * OUT: How many payloads left.
+						 */
+	uint32_t pad;                           /* IN: Must be zero. */
+	uint32_t name_total_size;               /* OUT: Total size of all transfer names */
+	uint32_t metadata_total_size;           /* OUT: Total size of all transfer metadata */
+
+	XEN_GUEST_HANDLE_64(xen_livepatch_status_t) status;  /*
+							      * OUT. Must have enough
+							      * space allocate for nr of them.
+							      */
+	XEN_GUEST_HANDLE_64(char) name;         /*
+						 * OUT: Array of names. Each member
+						 * may have an arbitrary length up to
+						 * XEN_LIVEPATCH_NAME_SIZE bytes. Must have
+						 * nr of them.
+						 */
+	XEN_GUEST_HANDLE_64(uint32) len;        /*
+						 * OUT: Array of lengths of name's.
+						 * Must have nr of them.
+						 */
+	XEN_GUEST_HANDLE_64(char) metadata;     /*
+						 * OUT: Array of metadata strings. Each
+						 * member may have an arbitrary length.
+						 * Must have nr of them.
+						 */
+	XEN_GUEST_HANDLE_64(uint32) metadata_len;  /*
+						    * OUT: Array of lengths of metadata's.
+						    * Must have nr of them.
+						    */
+};
+
+/*
+ * Perform an operation on the payload structure referenced by the `name` field.
+ * The operation request is asynchronous and the status should be retrieved
+ * by using either XEN_SYSCTL_LIVEPATCH_GET or XEN_SYSCTL_LIVEPATCH_LIST hypercall.
+ */
+#define XEN_SYSCTL_LIVEPATCH_ACTION 3
+struct xen_sysctl_livepatch_action {
+	struct xen_livepatch_name name;         /* IN, name of the patch. */
+#define LIVEPATCH_ACTION_UNLOAD       1
+#define LIVEPATCH_ACTION_REVERT       2
+#define LIVEPATCH_ACTION_APPLY        3
+#define LIVEPATCH_ACTION_REPLACE      4
+	uint32_t cmd;                           /* IN: LIVEPATCH_ACTION_*. */
+	uint32_t timeout;                       /* IN: If zero then uses */
+						/* hypervisor default. */
+						/* Or upper bound of time (ns) */
+						/* for operation to take. */
+
+/*
+ * Override default inter-module buildid dependency chain enforcement.
+ * Check only if module is built for given hypervisor by comparing buildid.
+ */
+#define LIVEPATCH_ACTION_APPLY_NODEPS (1 << 0)
+	uint32_t flags;                         /* IN: action flags. */
+						/* Provide additional parameters */
+						/* for an action. */
+	uint32_t pad;                           /* IN: Always zero. */
+};
+
+struct xen_sysctl_livepatch_op {
+	uint32_t cmd;                           /* IN: XEN_SYSCTL_LIVEPATCH_*. */
+	uint32_t pad;                           /* IN: Always zero. */
+	union {
+		struct xen_sysctl_livepatch_upload upload;
+		struct xen_sysctl_livepatch_list list;
+		struct xen_sysctl_livepatch_get get;
+		struct xen_sysctl_livepatch_action action;
+	} u;
+};
+
+#if defined(CONFIG_X86) || defined(CONFIG_X86_64)
+/*
+ * XEN_SYSCTL_get_cpu_policy (x86 specific)
+ *
+ * Return information about CPUID and MSR policies available on this host.
+ *  -       Raw: The real H/W values.
+ *  -      Host: The values Xen is using, (after command line overrides, etc).
+ *  -     Max_*: Maximum set of features a PV or HVM guest can use.  Includes
+ *               experimental features outside of security support.
+ *  - Default_*: Default set of features a PV or HVM guest can use.  This is
+ *               the security supported set.
+ * May fail with -EOPNOTSUPP if querying for PV or HVM data when support is
+ * compiled out of Xen.
+ */
+struct xen_sysctl_cpu_policy {
+#define XEN_SYSCTL_cpu_policy_raw          0
+#define XEN_SYSCTL_cpu_policy_host         1
+#define XEN_SYSCTL_cpu_policy_pv_max       2
+#define XEN_SYSCTL_cpu_policy_hvm_max      3
+#define XEN_SYSCTL_cpu_policy_pv_default   4
+#define XEN_SYSCTL_cpu_policy_hvm_default  5
+	uint32_t index;       /* IN: Which policy to query? */
+	uint32_t nr_leaves;   /*
+			       * IN/OUT: Number of leaves in/written to 'leaves',
+			       * or the max number if 'leaves' is NULL.
+			       */
+	uint32_t nr_msrs;     /*
+			       * IN/OUT: Number of MSRs in/written to 'msrs', or
+			       * the max number of if 'msrs' is NULL.
+			       */
+	uint32_t _rsvd;       /* Must be zero. */
+
+	XEN_GUEST_HANDLE_64(xen_cpuid_leaf_t) leaves; /* OUT */
+
+	XEN_GUEST_HANDLE_64(xen_msr_entry_t)  msrs;   /* OUT */
+};
+typedef struct xen_sysctl_cpu_policy xen_sysctl_cpu_policy_t;
+DEFINE_XEN_GUEST_HANDLE(xen_sysctl_cpu_policy_t);
+#endif
+
+#if defined(CONFIG_ARM) || defined(CONFIG_ARM64)
+/*
+ * XEN_SYSCTL_dt_overlay
+ * Performs addition/removal of device tree nodes under parent node using dtbo.
+ * This does in three steps:
+ *  - Adds/Removes the nodes from dt_host.
+ *  - Adds/Removes IRQ permission for the nodes.
+ *  - Adds/Removes MMIO accesses.
+ */
+struct xen_sysctl_dt_overlay {
+	XEN_GUEST_HANDLE_64(const_void) overlay_fdt;  /* IN: overlay fdt. */
+	uint32_t overlay_fdt_size;              /* IN: Overlay dtb size. */
+#define XEN_SYSCTL_DT_OVERLAY_ADD                   1
+#define XEN_SYSCTL_DT_OVERLAY_REMOVE                2
+	uint8_t overlay_op;                     /* IN: Add or remove. */
+	uint8_t pad[3];                         /* IN: Must be zero. */
+};
+#endif
 
 struct xen_sysctl {
 	uint32_t cmd;
@@ -131,11 +1277,41 @@ struct xen_sysctl {
 #define XEN_SYSCTL_livepatch_op                  27
 /* #define XEN_SYSCTL_set_parameter              28 */
 #define XEN_SYSCTL_get_cpu_policy                29
+#define XEN_SYSCTL_dt_overlay                    30
 	uint32_t interface_version; /* XEN_SYSCTL_INTERFACE_VERSION */
 	union {
+		struct xen_sysctl_readconsole       readconsole;
+		struct xen_sysctl_tbuf_op           tbuf_op;
 		struct xen_sysctl_physinfo          physinfo;
+		struct xen_sysctl_cputopoinfo       cputopoinfo;
+		struct xen_sysctl_pcitopoinfo       pcitopoinfo;
+		struct xen_sysctl_numainfo          numainfo;
+		struct xen_sysctl_sched_id          sched_id;
+		struct xen_sysctl_perfc_op          perfc_op;
 		struct xen_sysctl_getdomaininfolist getdomaininfolist;
+		struct xen_sysctl_debug_keys        debug_keys;
 		struct xen_sysctl_getcpuinfo        getcpuinfo;
+		struct xen_sysctl_availheap         availheap;
+		struct xen_sysctl_get_pmstat        get_pmstat;
+		struct xen_sysctl_cpu_hotplug       cpu_hotplug;
+		struct xen_sysctl_pm_op             pm_op;
+		struct xen_sysctl_page_offline_op   page_offline;
+		struct xen_sysctl_lockprof_op       lockprof_op;
+		struct xen_sysctl_cpupool_op        cpupool_op;
+		struct xen_sysctl_scheduler_op      scheduler_op;
+		struct xen_sysctl_coverage_op       coverage_op;
+		struct xen_sysctl_psr_cmt_op        psr_cmt_op;
+		struct xen_sysctl_psr_alloc         psr_alloc;
+		struct xen_sysctl_cpu_levelling_caps cpu_levelling_caps;
+		struct xen_sysctl_cpu_featureset    cpu_featureset;
+		struct xen_sysctl_livepatch_op      livepatch;
+#if defined(CONFIG_X86) || defined(CONFIG_X86_64)
+		struct xen_sysctl_cpu_policy        cpu_policy;
+#endif
+
+#if defined(CONFIG_ARM) || defined(CONFIG_ARM64)
+		struct xen_sysctl_dt_overlay        dt_overlay;
+#endif
 		uint8_t                             pad[128];
 	} u;
 };

--- a/include/zephyr/xen/public/trace.h
+++ b/include/zephyr/xen/public/trace.h
@@ -1,0 +1,331 @@
+/* SPDX-License-Identifier: MIT */
+
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Mark Williamson, (C) 2004 Intel Research Cambridge
+ * Copyright (C) 2005 Bin Ren
+ */
+
+#ifndef __XEN_PUBLIC_TRACE_H__
+#define __XEN_PUBLIC_TRACE_H__
+
+#define TRACE_EXTRA_MAX    7
+#define TRACE_EXTRA_SHIFT 28
+
+/* Trace classes */
+#define TRC_CLS_SHIFT 16
+#define TRC_GEN      0x0001f000    /* General trace            */
+#define TRC_SCHED    0x0002f000    /* Xen Scheduler trace      */
+#define TRC_DOM0OP   0x0004f000    /* Xen DOM0 operation trace */
+#define TRC_HVM      0x0008f000    /* Xen HVM trace            */
+#define TRC_MEM      0x0010f000    /* Xen memory trace         */
+#define TRC_PV       0x0020f000    /* Xen PV traces            */
+#define TRC_SHADOW   0x0040f000    /* Xen shadow tracing       */
+#define TRC_HW       0x0080f000    /* Xen hardware-related traces */
+#define TRC_GUEST    0x0800f000    /* Guest-generated traces   */
+#define TRC_ALL      0x0ffff000
+#define TRC_HD_TO_EVENT(x) ((x)&0x0fffffff)
+#define TRC_HD_CYCLE_FLAG (1UL<<31)
+#define TRC_HD_INCLUDES_CYCLE_COUNT(x) (!!((x) & TRC_HD_CYCLE_FLAG))
+#define TRC_HD_EXTRA(x)    (((x)>>TRACE_EXTRA_SHIFT)&TRACE_EXTRA_MAX)
+
+/* Trace subclasses */
+#define TRC_SUBCLS_SHIFT 12
+
+/* trace subclasses for SVM */
+#define TRC_HVM_ENTRYEXIT   0x00081000   /* VMENTRY and #VMEXIT       */
+#define TRC_HVM_HANDLER     0x00082000   /* various HVM handlers      */
+#define TRC_HVM_EMUL        0x00084000   /* emulated devices */
+
+#define TRC_SCHED_MIN       0x00021000   /* Just runstate changes */
+#define TRC_SCHED_CLASS     0x00022000   /* Scheduler-specific    */
+#define TRC_SCHED_VERBOSE   0x00028000   /* More inclusive scheduling */
+
+/*
+ * The highest 3 bits of the last 12 bits of TRC_SCHED_CLASS above are
+ * reserved for encoding what scheduler produced the information. The
+ * actual event is encoded in the last 9 bits.
+ *
+ * This means we have 8 scheduling IDs available (which means at most 8
+ * schedulers generating events) and, in each scheduler, up to 512
+ * different events.
+ */
+#define TRC_SCHED_ID_BITS 3
+#define TRC_SCHED_ID_SHIFT (TRC_SUBCLS_SHIFT - TRC_SCHED_ID_BITS)
+#define TRC_SCHED_ID_MASK (((1UL<<TRC_SCHED_ID_BITS) - 1) << TRC_SCHED_ID_SHIFT)
+#define TRC_SCHED_EVT_MASK (~(TRC_SCHED_ID_MASK))
+
+/* Per-scheduler IDs, to identify scheduler specific events */
+#define TRC_SCHED_CSCHED   0
+#define TRC_SCHED_CSCHED2  1
+/* #define XEN_SCHEDULER_SEDF 2 (Removed) */
+#define TRC_SCHED_ARINC653 3
+#define TRC_SCHED_RTDS     4
+#define TRC_SCHED_SNULL    5
+
+/* Per-scheduler tracing */
+#define TRC_SCHED_CLASS_EVT(_c, _e) \
+	((TRC_SCHED_CLASS | \
+	 ((TRC_SCHED_##_c << TRC_SCHED_ID_SHIFT) & TRC_SCHED_ID_MASK)) + \
+	  (_e & TRC_SCHED_EVT_MASK))
+
+/* Trace classes for DOM0 operations */
+#define TRC_DOM0_DOMOPS     0x00041000   /* Domains manipulations */
+
+/* Trace classes for Hardware */
+#define TRC_HW_PM           0x00801000   /* Power management traces */
+#define TRC_HW_IRQ          0x00802000   /* Traces relating to the handling of IRQs */
+
+/* Trace events per class */
+#define TRC_LOST_RECORDS        (TRC_GEN + 1)
+#define TRC_TRACE_WRAP_BUFFER  (TRC_GEN + 2)
+#define TRC_TRACE_CPU_CHANGE    (TRC_GEN + 3)
+
+#define TRC_SCHED_RUNSTATE_CHANGE   (TRC_SCHED_MIN + 1)
+#define TRC_SCHED_CONTINUE_RUNNING  (TRC_SCHED_MIN + 2)
+#define TRC_SCHED_DOM_ADD        (TRC_SCHED_VERBOSE +  1)
+#define TRC_SCHED_DOM_REM        (TRC_SCHED_VERBOSE +  2)
+#define TRC_SCHED_SLEEP          (TRC_SCHED_VERBOSE +  3)
+#define TRC_SCHED_WAKE           (TRC_SCHED_VERBOSE +  4)
+#define TRC_SCHED_YIELD          (TRC_SCHED_VERBOSE +  5)
+#define TRC_SCHED_BLOCK          (TRC_SCHED_VERBOSE +  6)
+#define TRC_SCHED_SHUTDOWN       (TRC_SCHED_VERBOSE +  7)
+#define TRC_SCHED_CTL            (TRC_SCHED_VERBOSE +  8)
+#define TRC_SCHED_ADJDOM         (TRC_SCHED_VERBOSE +  9)
+#define TRC_SCHED_SWITCH         (TRC_SCHED_VERBOSE + 10)
+#define TRC_SCHED_S_TIMER_FN     (TRC_SCHED_VERBOSE + 11)
+#define TRC_SCHED_T_TIMER_FN     (TRC_SCHED_VERBOSE + 12)
+#define TRC_SCHED_DOM_TIMER_FN   (TRC_SCHED_VERBOSE + 13)
+#define TRC_SCHED_SWITCH_INFPREV (TRC_SCHED_VERBOSE + 14)
+#define TRC_SCHED_SWITCH_INFNEXT (TRC_SCHED_VERBOSE + 15)
+#define TRC_SCHED_SHUTDOWN_CODE  (TRC_SCHED_VERBOSE + 16)
+#define TRC_SCHED_SWITCH_INFCONT (TRC_SCHED_VERBOSE + 17)
+
+#define TRC_DOM0_DOM_ADD         (TRC_DOM0_DOMOPS + 1)
+#define TRC_DOM0_DOM_REM         (TRC_DOM0_DOMOPS + 2)
+
+#define TRC_MEM_PAGE_GRANT_MAP      (TRC_MEM + 1)
+#define TRC_MEM_PAGE_GRANT_UNMAP    (TRC_MEM + 2)
+#define TRC_MEM_PAGE_GRANT_TRANSFER (TRC_MEM + 3)
+#define TRC_MEM_SET_P2M_ENTRY       (TRC_MEM + 4)
+#define TRC_MEM_DECREASE_RESERVATION (TRC_MEM + 5)
+#define TRC_MEM_POD_POPULATE        (TRC_MEM + 16)
+#define TRC_MEM_POD_ZERO_RECLAIM    (TRC_MEM + 17)
+#define TRC_MEM_POD_SUPERPAGE_SPLINTER (TRC_MEM + 18)
+
+#define TRC_PV_ENTRY   0x00201000 /* Hypervisor entry points for PV guests. */
+#define TRC_PV_SUBCALL 0x00202000 /* Sub-call in a multicall hypercall */
+
+#define TRC_PV_HYPERCALL             (TRC_PV_ENTRY +  1)
+#define TRC_PV_TRAP                  (TRC_PV_ENTRY +  3)
+#define TRC_PV_PAGE_FAULT            (TRC_PV_ENTRY +  4)
+#define TRC_PV_FORCED_INVALID_OP     (TRC_PV_ENTRY +  5)
+#define TRC_PV_EMULATE_PRIVOP        (TRC_PV_ENTRY +  6)
+#define TRC_PV_EMULATE_4GB           (TRC_PV_ENTRY +  7)
+#define TRC_PV_MATH_STATE_RESTORE    (TRC_PV_ENTRY +  8)
+#define TRC_PV_PAGING_FIXUP          (TRC_PV_ENTRY +  9)
+#define TRC_PV_GDT_LDT_MAPPING_FAULT (TRC_PV_ENTRY + 10)
+#define TRC_PV_PTWR_EMULATION        (TRC_PV_ENTRY + 11)
+#define TRC_PV_PTWR_EMULATION_PAE    (TRC_PV_ENTRY + 12)
+#define TRC_PV_HYPERCALL_V2          (TRC_PV_ENTRY + 13)
+#define TRC_PV_HYPERCALL_SUBCALL     (TRC_PV_SUBCALL + 14)
+
+/*
+ * TRC_PV_HYPERCALL_V2 format
+ *
+ * Only some of the hypercall argument are recorded. Bit fields A0 to
+ * A5 in the first extra word are set if the argument is present and
+ * the arguments themselves are packed sequentially in the following
+ * words.
+ *
+ * The TRC_64_FLAG bit is not set for these events (even if there are
+ * 64-bit arguments in the record).
+ *
+ * Word
+ * 0    bit 31 30|29 28|27 26|25 24|23 22|21 20|19 ... 0
+ *          A5   |A4   |A3   |A2   |A1   |A0   |Hypercall op
+ * 1    First 32 bit (or low word of first 64 bit) arg in record
+ * 2    Second 32 bit (or high word of first 64 bit) arg in record
+ * ...
+ *
+ * A0-A5 bitfield values:
+ *
+ *   00b  Argument not present
+ *   01b  32-bit argument present
+ *   10b  64-bit argument present
+ *   11b  Reserved
+ */
+#define TRC_PV_HYPERCALL_V2_ARG_32(i) (0x1 << (20 + 2*(i)))
+#define TRC_PV_HYPERCALL_V2_ARG_64(i) (0x2 << (20 + 2*(i)))
+#define TRC_PV_HYPERCALL_V2_ARG_MASK  (0xfff00000)
+
+#define TRC_SHADOW_NOT_SHADOW                 (TRC_SHADOW +  1)
+#define TRC_SHADOW_FAST_PROPAGATE             (TRC_SHADOW +  2)
+#define TRC_SHADOW_FAST_MMIO                  (TRC_SHADOW +  3)
+#define TRC_SHADOW_FALSE_FAST_PATH            (TRC_SHADOW +  4)
+#define TRC_SHADOW_MMIO                       (TRC_SHADOW +  5)
+#define TRC_SHADOW_FIXUP                      (TRC_SHADOW +  6)
+#define TRC_SHADOW_DOMF_DYING                 (TRC_SHADOW +  7)
+#define TRC_SHADOW_EMULATE                    (TRC_SHADOW +  8)
+#define TRC_SHADOW_EMULATE_UNSHADOW_USER      (TRC_SHADOW +  9)
+#define TRC_SHADOW_EMULATE_UNSHADOW_EVTINJ    (TRC_SHADOW + 10)
+#define TRC_SHADOW_EMULATE_UNSHADOW_UNHANDLED (TRC_SHADOW + 11)
+#define TRC_SHADOW_WRMAP_BF                   (TRC_SHADOW + 12)
+#define TRC_SHADOW_PREALLOC_UNPIN             (TRC_SHADOW + 13)
+#define TRC_SHADOW_RESYNC_FULL                (TRC_SHADOW + 14)
+#define TRC_SHADOW_RESYNC_ONLY                (TRC_SHADOW + 15)
+
+/* trace events per subclass */
+#define TRC_HVM_NESTEDFLAG      (0x400)
+#define TRC_HVM_VMENTRY         (TRC_HVM_ENTRYEXIT + 0x01)
+#define TRC_HVM_VMEXIT          (TRC_HVM_ENTRYEXIT + 0x02)
+#define TRC_HVM_VMEXIT64        (TRC_HVM_ENTRYEXIT + TRC_64_FLAG + 0x02)
+#define TRC_HVM_PF_XEN          (TRC_HVM_HANDLER + 0x01)
+#define TRC_HVM_PF_XEN64        (TRC_HVM_HANDLER + TRC_64_FLAG + 0x01)
+#define TRC_HVM_PF_INJECT       (TRC_HVM_HANDLER + 0x02)
+#define TRC_HVM_PF_INJECT64     (TRC_HVM_HANDLER + TRC_64_FLAG + 0x02)
+#define TRC_HVM_INJ_EXC         (TRC_HVM_HANDLER + 0x03)
+#define TRC_HVM_INJ_VIRQ        (TRC_HVM_HANDLER + 0x04)
+#define TRC_HVM_REINJ_VIRQ      (TRC_HVM_HANDLER + 0x05)
+#define TRC_HVM_IO_READ         (TRC_HVM_HANDLER + 0x06)
+#define TRC_HVM_IO_WRITE        (TRC_HVM_HANDLER + 0x07)
+#define TRC_HVM_CR_READ         (TRC_HVM_HANDLER + 0x08)
+#define TRC_HVM_CR_READ64       (TRC_HVM_HANDLER + TRC_64_FLAG + 0x08)
+#define TRC_HVM_CR_WRITE        (TRC_HVM_HANDLER + 0x09)
+#define TRC_HVM_CR_WRITE64      (TRC_HVM_HANDLER + TRC_64_FLAG + 0x09)
+#define TRC_HVM_DR_READ         (TRC_HVM_HANDLER + 0x0A)
+#define TRC_HVM_DR_WRITE        (TRC_HVM_HANDLER + 0x0B)
+#define TRC_HVM_MSR_READ        (TRC_HVM_HANDLER + 0x0C)
+#define TRC_HVM_MSR_WRITE       (TRC_HVM_HANDLER + 0x0D)
+#define TRC_HVM_CPUID           (TRC_HVM_HANDLER + 0x0E)
+#define TRC_HVM_INTR            (TRC_HVM_HANDLER + 0x0F)
+#define TRC_HVM_NMI             (TRC_HVM_HANDLER + 0x10)
+#define TRC_HVM_SMI             (TRC_HVM_HANDLER + 0x11)
+#define TRC_HVM_VMMCALL         (TRC_HVM_HANDLER + 0x12)
+#define TRC_HVM_HLT             (TRC_HVM_HANDLER + 0x13)
+#define TRC_HVM_INVLPG          (TRC_HVM_HANDLER + 0x14)
+#define TRC_HVM_INVLPG64        (TRC_HVM_HANDLER + TRC_64_FLAG + 0x14)
+#define TRC_HVM_MCE             (TRC_HVM_HANDLER + 0x15)
+#define TRC_HVM_IOPORT_READ     (TRC_HVM_HANDLER + 0x16)
+#define TRC_HVM_IOMEM_READ      (TRC_HVM_HANDLER + 0x17)
+#define TRC_HVM_CLTS            (TRC_HVM_HANDLER + 0x18)
+#define TRC_HVM_LMSW            (TRC_HVM_HANDLER + 0x19)
+#define TRC_HVM_LMSW64          (TRC_HVM_HANDLER + TRC_64_FLAG + 0x19)
+#define TRC_HVM_RDTSC           (TRC_HVM_HANDLER + 0x1a)
+#define TRC_HVM_INTR_WINDOW     (TRC_HVM_HANDLER + 0x20)
+#define TRC_HVM_NPF             (TRC_HVM_HANDLER + 0x21)
+#define TRC_HVM_REALMODE_EMULATE (TRC_HVM_HANDLER + 0x22)
+#define TRC_HVM_TRAP             (TRC_HVM_HANDLER + 0x23)
+#define TRC_HVM_TRAP_DEBUG       (TRC_HVM_HANDLER + 0x24)
+#define TRC_HVM_VLAPIC           (TRC_HVM_HANDLER + 0x25)
+#define TRC_HVM_XCR_READ64      (TRC_HVM_HANDLER + TRC_64_FLAG + 0x26)
+#define TRC_HVM_XCR_WRITE64     (TRC_HVM_HANDLER + TRC_64_FLAG + 0x27)
+
+#define TRC_HVM_IOPORT_WRITE    (TRC_HVM_HANDLER + 0x216)
+#define TRC_HVM_IOMEM_WRITE     (TRC_HVM_HANDLER + 0x217)
+
+/* Trace events for emulated devices */
+#define TRC_HVM_EMUL_HPET_START_TIMER  (TRC_HVM_EMUL + 0x1)
+#define TRC_HVM_EMUL_PIT_START_TIMER   (TRC_HVM_EMUL + 0x2)
+#define TRC_HVM_EMUL_RTC_START_TIMER   (TRC_HVM_EMUL + 0x3)
+#define TRC_HVM_EMUL_LAPIC_START_TIMER (TRC_HVM_EMUL + 0x4)
+#define TRC_HVM_EMUL_HPET_STOP_TIMER   (TRC_HVM_EMUL + 0x5)
+#define TRC_HVM_EMUL_PIT_STOP_TIMER    (TRC_HVM_EMUL + 0x6)
+#define TRC_HVM_EMUL_RTC_STOP_TIMER    (TRC_HVM_EMUL + 0x7)
+#define TRC_HVM_EMUL_LAPIC_STOP_TIMER  (TRC_HVM_EMUL + 0x8)
+#define TRC_HVM_EMUL_PIT_TIMER_CB      (TRC_HVM_EMUL + 0x9)
+#define TRC_HVM_EMUL_LAPIC_TIMER_CB    (TRC_HVM_EMUL + 0xA)
+#define TRC_HVM_EMUL_PIC_INT_OUTPUT    (TRC_HVM_EMUL + 0xB)
+#define TRC_HVM_EMUL_PIC_KICK          (TRC_HVM_EMUL + 0xC)
+#define TRC_HVM_EMUL_PIC_INTACK        (TRC_HVM_EMUL + 0xD)
+#define TRC_HVM_EMUL_PIC_POSEDGE       (TRC_HVM_EMUL + 0xE)
+#define TRC_HVM_EMUL_PIC_NEGEDGE       (TRC_HVM_EMUL + 0xF)
+#define TRC_HVM_EMUL_PIC_PEND_IRQ_CALL (TRC_HVM_EMUL + 0x10)
+#define TRC_HVM_EMUL_LAPIC_PIC_INTR    (TRC_HVM_EMUL + 0x11)
+
+/* trace events for per class */
+#define TRC_PM_FREQ_CHANGE      (TRC_HW_PM + 0x01)
+#define TRC_PM_IDLE_ENTRY       (TRC_HW_PM + 0x02)
+#define TRC_PM_IDLE_EXIT        (TRC_HW_PM + 0x03)
+
+/* Trace events for IRQs */
+#define TRC_HW_IRQ_MOVE_CLEANUP_DELAY (TRC_HW_IRQ + 0x1)
+#define TRC_HW_IRQ_MOVE_CLEANUP       (TRC_HW_IRQ + 0x2)
+#define TRC_HW_IRQ_BIND_VECTOR        (TRC_HW_IRQ + 0x3)
+#define TRC_HW_IRQ_CLEAR_VECTOR       (TRC_HW_IRQ + 0x4)
+#define TRC_HW_IRQ_MOVE_FINISH        (TRC_HW_IRQ + 0x5)
+#define TRC_HW_IRQ_ASSIGN_VECTOR      (TRC_HW_IRQ + 0x6)
+#define TRC_HW_IRQ_UNMAPPED_VECTOR    (TRC_HW_IRQ + 0x7)
+#define TRC_HW_IRQ_HANDLED            (TRC_HW_IRQ + 0x8)
+
+/*
+ * Event Flags
+ *
+ * Some events (e.g, TRC_PV_TRAP and TRC_HVM_IOMEM_READ) have multiple
+ * record formats.  These event flags distinguish between the
+ * different formats.
+ */
+#define TRC_64_FLAG 0x100 /* Addresses are 64 bits (instead of 32 bits) */
+
+/* This structure represents a single trace buffer record. */
+struct t_rec {
+	uint32_t event:28;
+	uint32_t extra_u32:3;         /* # entries in trailing extra_u32[] array */
+	uint32_t cycles_included:1;   /* u.cycles or u.no_cycles? */
+	union {
+		struct {
+			uint32_t cycles_lo, cycles_hi; /* cycle counter timestamp */
+			uint32_t extra_u32[7];         /* event data items */
+		} cycles;
+		struct {
+			uint32_t extra_u32[7];         /* event data items */
+		} nocycles;
+	} u;
+};
+
+/*
+ * This structure contains the metadata for a single trace buffer.  The head
+ * field, indexes into an array of struct t_rec's.
+ */
+struct t_buf {
+	/* Assume the data buffer size is X.  X is generally not a power of 2.
+	 * CONS and PROD are incremented modulo (2*X):
+	 *     0 <= cons < 2*X
+	 *     0 <= prod < 2*X
+	 * This is done because addition modulo X breaks at 2^32 when X is not a
+	 * power of 2:
+	 *     (((2^32 - 1) % X) + 1) % X != (2^32) % X
+	 */
+	uint32_t cons;   /* Offset of next item to be consumed by control tools. */
+	uint32_t prod;   /* Offset of next item to be produced by Xen.           */
+	/*  Records follow immediately after the meta-data header.    */
+};
+
+/* Structure used to pass MFNs to the trace buffers back to trace consumers.
+ * Offset is an offset into the mapped structure where the mfn list will be held.
+ * MFNs will be at ((unsigned long *)(t_info))+(t_info->cpu_offset[cpu]).
+ */
+struct t_info {
+	uint16_t tbuf_size; /* Size in pages of each trace buffer */
+	uint16_t mfn_offset[];  /* Offset within t_info structure of the page list per cpu */
+	/* MFN lists immediately after the header */
+};
+
+#endif /* __XEN_PUBLIC_TRACE_H__ */

--- a/include/zephyr/xen/public/version.h
+++ b/include/zephyr/xen/public/version.h
@@ -22,6 +22,94 @@
 
 /* arg == xen_extraversion_t. */
 #define XENVER_extraversion 1
-#define XEN_EXTRAVERSION_LEN 16
+typedef char xen_extraversion_t[16];
+#define XEN_EXTRAVERSION_LEN (sizeof(xen_extraversion_t))
+
+/* arg == xen_compile_info_t. */
+#define XENVER_compile_info 2
+struct xen_compile_info {
+	char compiler[64];
+	char compile_by[16];
+	char compile_domain[32];
+	char compile_date[32];
+};
+typedef struct xen_compile_info xen_compile_info_t;
+
+#define XENVER_capabilities 3
+typedef char xen_capabilities_info_t[1024];
+#define XEN_CAPABILITIES_INFO_LEN (sizeof(xen_capabilities_info_t))
+
+#define XENVER_changeset 4
+typedef char xen_changeset_info_t[64];
+#define XEN_CHANGESET_INFO_LEN (sizeof(xen_changeset_info_t))
+
+/*
+ * This API is problematic.
+ *
+ * It is only applicable to guests which share pagetables with Xen (x86 PV
+ * guests), but unfortunately has leaked into other guest types and
+ * architectures with an expectation of never failing.
+ *
+ * It is intended to identify the virtual address split between guest kernel
+ * and Xen.
+ *
+ * For 32bit PV guests, there is a split, and it is variable (between two
+ * fixed bounds), and this boundary is reported to guests.  The detail missing
+ * from the hypercall is that the second boundary is the 32bit architectural
+ * boundary at 4G.
+ *
+ * For 64bit PV guests, Xen lives at the bottom of the upper canonical range.
+ * This hypercall happens to report the architectural boundary, not the one
+ * which would be necessary to make a variable split work.  As such, this
+ * hypercall entirely useless for 64bit PV guests, and all inspected
+ * implementations at the time of writing were found to have compile time
+ * expectations about the split.
+ *
+ * For architectures where this hypercall is implemented, for backwards
+ * compatibility with the expectation of the hypercall never failing Xen will
+ * return 0 instead of failing with -ENOSYS in cases where the guest should
+ * not be making the hypercall.
+ */
+#define XENVER_platform_parameters 5
+struct xen_platform_parameters {
+	xen_ulong_t virt_start;
+};
+typedef struct xen_platform_parameters xen_platform_parameters_t;
+
+#define XENVER_get_features 6
+struct xen_feature_info {
+	uint32_t     submap_idx;    /* IN: which 32-bit submap to return */
+	uint32_t     submap;        /* OUT: 32-bit submap */
+};
+typedef struct xen_feature_info xen_feature_info_t;
+
+/* Declares the features reported by XENVER_get_features. */
+#include "features.h"
+
+/* arg == NULL; returns host memory page size. */
+#define XENVER_pagesize 7
+
+/* arg == xen_domain_handle_t.
+ *
+ * The toolstack fills it out for guest consumption. It is intended to hold
+ * the UUID of the guest.
+ */
+#define XENVER_guest_handle 8
+
+#define XENVER_commandline 9
+typedef char xen_commandline_t[1024];
+
+/*
+ * Return value is the number of bytes written, or XEN_Exx on error.
+ * Calling with empty parameter returns the size of build_id.
+ */
+#define XENVER_build_id 10
+struct xen_build_id {
+	/* IN: size of buf[]. */
+	uint32_t        len;
+	/* OUT: Variable length buffer with build_id. */
+	unsigned char   buf[XEN_FLEX_ARRAY_DIM];
+};
+typedef struct xen_build_id xen_build_id_t;
 
 #endif /* __XEN_PUBLIC_VERSION_H__ */

--- a/include/zephyr/xen/public/xen.h
+++ b/include/zephyr/xen/public/xen.h
@@ -141,6 +141,370 @@ DEFINE_XEN_GUEST_HANDLE(xen_ulong_t);
 #define __HYPERVISOR_dm_op				41
 #define __HYPERVISOR_hypfs_op				42
 
+/* Architecture-specific hypercall definitions. */
+#define __HYPERVISOR_arch_0               48
+#define __HYPERVISOR_arch_1               49
+#define __HYPERVISOR_arch_2               50
+#define __HYPERVISOR_arch_3               51
+#define __HYPERVISOR_arch_4               52
+#define __HYPERVISOR_arch_5               53
+#define __HYPERVISOR_arch_6               54
+#define __HYPERVISOR_arch_7               55
+
+/* ` } */
+
+/*
+ * HYPERCALL COMPATIBILITY.
+ */
+
+/* New sched_op hypercall introduced in 0x00030101. */
+#if __XEN_INTERFACE_VERSION__ < 0x00030101
+#undef __HYPERVISOR_sched_op
+#define __HYPERVISOR_sched_op __HYPERVISOR_sched_op_compat
+#endif
+
+/* New event-channel and physdev hypercalls introduced in 0x00030202. */
+#if __XEN_INTERFACE_VERSION__ < 0x00030202
+#undef __HYPERVISOR_event_channel_op
+#define __HYPERVISOR_event_channel_op __HYPERVISOR_event_channel_op_compat
+#undef __HYPERVISOR_physdev_op
+#define __HYPERVISOR_physdev_op __HYPERVISOR_physdev_op_compat
+#endif
+
+/* New platform_op hypercall introduced in 0x00030204. */
+#if __XEN_INTERFACE_VERSION__ < 0x00030204
+#define __HYPERVISOR_dom0_op __HYPERVISOR_platform_op
+#endif
+
+/*
+ * VIRTUAL INTERRUPTS
+ *
+ * Virtual interrupts that a guest OS may receive from Xen.
+ *
+ * In the side comments, 'V.' denotes a per-VCPU VIRQ while 'G.' denotes a
+ * global VIRQ. The former can be bound once per VCPU and cannot be re-bound.
+ * The latter can be allocated only once per guest: they must initially be
+ * allocated to VCPU0 but can subsequently be re-bound.
+ */
+/* ` enum virq { */
+#define VIRQ_TIMER      0  /* V. Timebase update, and/or requested timeout.  */
+#define VIRQ_DEBUG      1  /* V. Request guest to dump debug info.           */
+#define VIRQ_CONSOLE    2  /* G. (DOM0) Bytes received on emergency console. */
+#define VIRQ_DOM_EXC    3  /* G. (DOM0) Exceptional event for some domain.   */
+#define VIRQ_TBUF       4  /* G. (DOM0) Trace buffer has records available.  */
+#define VIRQ_DEBUGGER   6  /* G. (DOM0) A domain has paused for debugging.   */
+#define VIRQ_XENOPROF   7  /* V. XenOprofile interrupt: new sample available */
+#define VIRQ_CON_RING   8  /* G. (DOM0) Bytes received on console            */
+#define VIRQ_PCPU_STATE 9  /* G. (DOM0) PCPU state changed                   */
+#define VIRQ_MEM_EVENT  10 /* G. (DOM0) A memory event has occurred          */
+#define VIRQ_ARGO       11 /* G. Argo interdomain message notification       */
+#define VIRQ_ENOMEM     12 /* G. (DOM0) Low on heap memory       */
+#define VIRQ_XENPMU     13 /* V.  PMC interrupt                              */
+
+/* Architecture-specific VIRQ definitions. */
+#define VIRQ_ARCH_0    16
+#define VIRQ_ARCH_1    17
+#define VIRQ_ARCH_2    18
+#define VIRQ_ARCH_3    19
+#define VIRQ_ARCH_4    20
+#define VIRQ_ARCH_5    21
+#define VIRQ_ARCH_6    22
+#define VIRQ_ARCH_7    23
+/* ` } */
+
+#define NR_VIRQS       24
+
+/*
+ * ` enum neg_errnoval
+ * ` HYPERVISOR_mmu_update(const struct mmu_update reqs[],
+ * `                       unsigned count, unsigned *done_out,
+ * `                       unsigned foreigndom)
+ * `
+ * @reqs is an array of mmu_update_t structures ((ptr, val) pairs).
+ * @count is the length of the above array.
+ * @pdone is an output parameter indicating number of completed operations
+ * @foreigndom[15:0]: FD, the expected owner of data pages referenced in this
+ *                    hypercall invocation. Can be DOMID_SELF.
+ * @foreigndom[31:16]: PFD, the expected owner of pagetable pages referenced
+ *                     in this hypercall invocation. The value of this field
+ *                     (x) encodes the PFD as follows:
+ *                     x == 0 => PFD == DOMID_SELF
+ *                     x != 0 => PFD == x - 1
+ *
+ * Sub-commands: ptr[1:0] specifies the appropriate MMU_* command.
+ * -------------
+ * ptr[1:0] == MMU_NORMAL_PT_UPDATE:
+ * Updates an entry in a page table belonging to PFD. If updating an L1 table,
+ * and the new table entry is valid/present, the mapped frame must belong to
+ * FD. If attempting to map an I/O page then the caller assumes the privilege
+ * of the FD.
+ * FD == DOMID_IO: Permit /only/ I/O mappings, at the priv level of the caller.
+ * FD == DOMID_XEN: Map restricted areas of Xen's heap space.
+ * ptr[:2]  -- Machine address of the page-table entry to modify.
+ * val      -- Value to write.
+ *
+ * There also certain implicit requirements when using this hypercall. The
+ * pages that make up a pagetable must be mapped read-only in the guest.
+ * This prevents uncontrolled guest updates to the pagetable. Xen strictly
+ * enforces this, and will disallow any pagetable update which will end up
+ * mapping pagetable page RW, and will disallow using any writable page as a
+ * pagetable. In practice it means that when constructing a page table for a
+ * process, thread, etc, we MUST be very dilligient in following these rules:
+ *  1). Start with top-level page (PGD or in Xen language: L4). Fill out
+ *      the entries.
+ *  2). Keep on going, filling out the upper (PUD or L3), and middle (PMD
+ *      or L2).
+ *  3). Start filling out the PTE table (L1) with the PTE entries. Once
+ *      done, make sure to set each of those entries to RO (so writeable bit
+ *      is unset). Once that has been completed, set the PMD (L2) for this
+ *      PTE table as RO.
+ *  4). When completed with all of the PMD (L2) entries, and all of them have
+ *      been set to RO, make sure to set RO the PUD (L3). Do the same
+ *      operation on PGD (L4) pagetable entries that have a PUD (L3) entry.
+ *  5). Now before you can use those pages (so setting the cr3), you MUST also
+ *      pin them so that the hypervisor can verify the entries. This is done
+ *      via the HYPERVISOR_mmuext_op(MMUEXT_PIN_L4_TABLE, guest physical frame
+ *      number of the PGD (L4)). And this point the HYPERVISOR_mmuext_op(
+ *      MMUEXT_NEW_BASEPTR, guest physical frame number of the PGD (L4)) can be
+ *      issued.
+ * For 32-bit guests, the L4 is not used (as there is less pagetables), so
+ * instead use L3.
+ * At this point the pagetables can be modified using the MMU_NORMAL_PT_UPDATE
+ * hypercall. Also if so desired the OS can also try to write to the PTE
+ * and be trapped by the hypervisor (as the PTE entry is RO).
+ *
+ * To deallocate the pages, the operations are the reverse of the steps
+ * mentioned above. The argument is MMUEXT_UNPIN_TABLE for all levels and the
+ * pagetable MUST not be in use (meaning that the cr3 is not set to it).
+ *
+ * ptr[1:0] == MMU_MACHPHYS_UPDATE:
+ * Updates an entry in the machine->pseudo-physical mapping table.
+ * ptr[:2]  -- Machine address within the frame whose mapping to modify.
+ *             The frame must belong to the FD, if one is specified.
+ * val      -- Value to write into the mapping entry.
+ *
+ * ptr[1:0] == MMU_PT_UPDATE_PRESERVE_AD:
+ * As MMU_NORMAL_PT_UPDATE above, but A/D bits currently in the PTE are ORed
+ * with those in @val.
+ *
+ * ptr[1:0] == MMU_PT_UPDATE_NO_TRANSLATE:
+ * As MMU_NORMAL_PT_UPDATE above, but @val is not translated though FD
+ * page tables.
+ *
+ * @val is usually the machine frame number along with some attributes.
+ * The attributes by default follow the architecture defined bits. Meaning that
+ * if this is a X86_64 machine and four page table layout is used, the layout
+ * of val is:
+ *  - 63 if set means No execute (NX)
+ *  - 46-13 the machine frame number
+ *  - 12 available for guest
+ *  - 11 available for guest
+ *  - 10 available for guest
+ *  - 9 available for guest
+ *  - 8 global
+ *  - 7 PAT (PSE is disabled, must use hypercall to make 4MB or 2MB pages)
+ *  - 6 dirty
+ *  - 5 accessed
+ *  - 4 page cached disabled
+ *  - 3 page write through
+ *  - 2 userspace accessible
+ *  - 1 writeable
+ *  - 0 present
+ *
+ *  The one bits that does not fit with the default layout is the PAGE_PSE
+ *  also called PAGE_PAT). The MMUEXT_[UN]MARK_SUPER arguments to the
+ *  HYPERVISOR_mmuext_op serve as mechanism to set a pagetable to be 4MB
+ *  (or 2MB) instead of using the PAGE_PSE bit.
+ *
+ *  The reason that the PAGE_PSE (bit 7) is not being utilized is due to Xen
+ *  using it as the Page Attribute Table (PAT) bit - for details on it please
+ *  refer to Intel SDM 10.12. The PAT allows to set the caching attributes of
+ *  pages instead of using MTRRs.
+ *
+ *  The PAT MSR is as follows (it is a 64-bit value, each entry is 8 bits):
+ *                    PAT4                 PAT0
+ *  +-----+-----+----+----+----+-----+----+----+
+ *  | UC  | UC- | WC | WB | UC | UC- | WC | WB |  <= Linux
+ *  +-----+-----+----+----+----+-----+----+----+
+ *  | UC  | UC- | WT | WB | UC | UC- | WT | WB |  <= BIOS (default when machine boots)
+ *  +-----+-----+----+----+----+-----+----+----+
+ *  | rsv | rsv | WP | WC | UC | UC- | WT | WB |  <= Xen
+ *  +-----+-----+----+----+----+-----+----+----+
+ *
+ *  The lookup of this index table translates to looking up
+ *  Bit 7, Bit 4, and Bit 3 of val entry:
+ *
+ *  PAT/PSE (bit 7) ... PCD (bit 4) .. PWT (bit 3).
+ *
+ *  If all bits are off, then we are using PAT0. If bit 3 turned on,
+ *  then we are using PAT1, if bit 3 and bit 4, then PAT2..
+ *
+ *  As you can see, the Linux PAT1 translates to PAT4 under Xen. Which means
+ *  that if a guest that follows Linux's PAT setup and would like to set Write
+ *  Combined on pages it MUST use PAT4 entry. Meaning that Bit 7 (PAGE_PAT) is
+ *  set. For example, under Linux it only uses PAT0, PAT1, and PAT2 for the
+ *  caching as:
+ *
+ *   WB = none (so PAT0)
+ *   WC = PWT (bit 3 on)
+ *   UC = PWT | PCD (bit 3 and 4 are on).
+ *
+ * To make it work with Xen, it needs to translate the WC bit as so:
+ *
+ *  PWT (so bit 3 on) --> PAT (so bit 7 is on) and clear bit 3
+ *
+ * And to translate back it would:
+ *
+ * PAT (bit 7 on) --> PWT (bit 3 on) and clear bit 7.
+ */
+#define MMU_NORMAL_PT_UPDATE       0 /* checked '*ptr = val'. ptr is MA.      */
+#define MMU_MACHPHYS_UPDATE        1 /* ptr = MA of frame to modify entry for */
+#define MMU_PT_UPDATE_PRESERVE_AD  2 /* atomically: *ptr = val | (*ptr&(A|D)) */
+#define MMU_PT_UPDATE_NO_TRANSLATE 3 /* checked '*ptr = val'. ptr is MA.      */
+				     /* val never translated.                 */
+
+/*
+ * MMU EXTENDED OPERATIONS
+ *
+ * ` enum neg_errnoval
+ * ` HYPERVISOR_mmuext_op(mmuext_op_t uops[],
+ * `                      unsigned int count,
+ * `                      unsigned int *pdone,
+ * `                      unsigned int foreigndom)
+ */
+/* HYPERVISOR_mmuext_op() accepts a list of mmuext_op structures.
+ * A foreigndom (FD) can be specified (or DOMID_SELF for none).
+ * Where the FD has some effect, it is described below.
+ *
+ * cmd: MMUEXT_(UN)PIN_*_TABLE
+ * mfn: Machine frame number to be (un)pinned as a p.t. page.
+ *      The frame must belong to the FD, if one is specified.
+ *
+ * cmd: MMUEXT_NEW_BASEPTR
+ * mfn: Machine frame number of new page-table base to install in MMU.
+ *
+ * cmd: MMUEXT_NEW_USER_BASEPTR [x86/64 only]
+ * mfn: Machine frame number of new page-table base to install in MMU
+ *      when in user space.
+ *
+ * cmd: MMUEXT_TLB_FLUSH_LOCAL
+ * No additional arguments. Flushes local TLB.
+ *
+ * cmd: MMUEXT_INVLPG_LOCAL
+ * linear_addr: Linear address to be flushed from the local TLB.
+ *
+ * cmd: MMUEXT_TLB_FLUSH_MULTI
+ * vcpumask: Pointer to bitmap of VCPUs to be flushed.
+ *
+ * cmd: MMUEXT_INVLPG_MULTI
+ * linear_addr: Linear address to be flushed.
+ * vcpumask: Pointer to bitmap of VCPUs to be flushed.
+ *
+ * cmd: MMUEXT_TLB_FLUSH_ALL
+ * No additional arguments. Flushes all VCPUs' TLBs.
+ *
+ * cmd: MMUEXT_INVLPG_ALL
+ * linear_addr: Linear address to be flushed from all VCPUs' TLBs.
+ *
+ * cmd: MMUEXT_FLUSH_CACHE
+ * No additional arguments. Writes back and flushes cache contents.
+ *
+ * cmd: MMUEXT_FLUSH_CACHE_GLOBAL
+ * No additional arguments. Writes back and flushes cache contents
+ * on all CPUs in the system.
+ *
+ * cmd: MMUEXT_SET_LDT
+ * linear_addr: Linear address of LDT base (NB. must be page-aligned).
+ * nr_ents: Number of entries in LDT.
+ *
+ * cmd: MMUEXT_CLEAR_PAGE
+ * mfn: Machine frame number to be cleared.
+ *
+ * cmd: MMUEXT_COPY_PAGE
+ * mfn: Machine frame number of the destination page.
+ * src_mfn: Machine frame number of the source page.
+ *
+ * cmd: MMUEXT_[UN]MARK_SUPER
+ * mfn: Machine frame number of head of superpage to be [un]marked.
+ */
+/* ` enum mmuext_cmd { */
+#define MMUEXT_PIN_L1_TABLE      0
+#define MMUEXT_PIN_L2_TABLE      1
+#define MMUEXT_PIN_L3_TABLE      2
+#define MMUEXT_PIN_L4_TABLE      3
+#define MMUEXT_UNPIN_TABLE       4
+#define MMUEXT_NEW_BASEPTR       5
+#define MMUEXT_TLB_FLUSH_LOCAL   6
+#define MMUEXT_INVLPG_LOCAL      7
+#define MMUEXT_TLB_FLUSH_MULTI   8
+#define MMUEXT_INVLPG_MULTI      9
+#define MMUEXT_TLB_FLUSH_ALL    10
+#define MMUEXT_INVLPG_ALL       11
+#define MMUEXT_FLUSH_CACHE      12
+#define MMUEXT_SET_LDT          13
+#define MMUEXT_NEW_USER_BASEPTR 15
+#define MMUEXT_CLEAR_PAGE       16
+#define MMUEXT_COPY_PAGE        17
+#define MMUEXT_FLUSH_CACHE_GLOBAL 18
+#define MMUEXT_MARK_SUPER       19
+#define MMUEXT_UNMARK_SUPER     20
+/* ` } */
+
+#ifndef __ASSEMBLY__
+struct mmuext_op {
+	unsigned int cmd; /* => enum mmuext_cmd */
+	union {
+		/*
+		 * [UN]PIN_TABLE, NEW_BASEPTR, NEW_USER_BASEPTR
+		 * CLEAR_PAGE, COPY_PAGE, [UN]MARK_SUPER
+		 */
+		xen_pfn_t mfn;
+		/* INVLPG_LOCAL, INVLPG_ALL, SET_LDT */
+		unsigned long linear_addr;
+	} arg1;
+	union {
+		/* SET_LDT */
+		unsigned int nr_ents;
+		/* TLB_FLUSH_MULTI, INVLPG_MULTI */
+#if __XEN_INTERFACE_VERSION__ >= 0x00030205
+		XEN_GUEST_HANDLE(const_void) vcpumask;
+#else
+		const void *vcpumask;
+#endif
+		/* COPY_PAE */
+		xen_pfn_t src_mfn;
+	} arg2;
+};
+typedef struct mmuext_op mmuext_op_t;
+DEFINE_XEN_GUEST_HANDLE(mmuext_op_t);
+#endif
+
+/*
+ * ` enum neg_errnoval
+ * ` HYPERVISOR_update_va_mapping(unsigned long va, u64 val,
+ * `                              enum uvm_flags flags)
+ * `
+ * ` enum neg_errnoval
+ * ` HYPERVISOR_update_va_mapping_otherdomain(unsigned long va, u64 val,
+ * `                                          enum uvm_flags flags,
+ * `                                          domid_t domid)
+ * `
+ * ` @va: The virtual address whose mapping we want to change
+ * ` @val: The new page table entry, must contain a machine address
+ * ` @flags: Control TLB flushes
+ */
+/* These are passed as 'flags' to update_va_mapping. They can be ORed. */
+/* When specifying UVMF_MULTI, also OR in a pointer to a CPU bitmap.   */
+/* UVMF_LOCAL is merely UVMF_MULTI with a NULL bitmap pointer.         */
+/* ` enum uvm_flags { */
+#define UVMF_NONE           (xen_mk_ulong(0)<<0) /* No flushing at all.   */
+#define UVMF_TLB_FLUSH      (xen_mk_ulong(1)<<0) /* Flush entire TLB(s).  */
+#define UVMF_INVLPG         (xen_mk_ulong(2)<<0) /* Flush only one entry. */
+#define UVMF_FLUSHTYPE_MASK (xen_mk_ulong(3)<<0)
+#define UVMF_MULTI          (xen_mk_ulong(0)<<2) /* Flush subset of TLBs. */
+#define UVMF_LOCAL          (xen_mk_ulong(0)<<2) /* Flush local TLB.      */
+#define UVMF_ALL            (xen_mk_ulong(1)<<2) /* Flush all TLBs.       */
+/* ` } */
 /*
  * ` int
  * ` HYPERVISOR_console_io(unsigned int cmd,
@@ -167,6 +531,58 @@ DEFINE_XEN_GUEST_HANDLE(xen_ulong_t);
  */
 #define CONSOLEIO_write		0
 #define CONSOLEIO_read		1
+/*
+ * Commands to HYPERVISOR_vm_assist().
+ */
+#define VMASST_CMD_enable                0
+#define VMASST_CMD_disable               1
+
+/* x86/32 guests: simulate full 4GB segment limits. */
+#define VMASST_TYPE_4gb_segments         0
+
+/* x86/32 guests: trap (vector 15) whenever above vmassist is used. */
+#define VMASST_TYPE_4gb_segments_notify  1
+
+/*
+ * x86 guests: support writes to bottom-level PTEs.
+ * NB1. Page-directory entries cannot be written.
+ * NB2. Guest must continue to remove all writable mappings of PTEs.
+ */
+#define VMASST_TYPE_writable_pagetables  2
+
+/* x86/PAE guests: support PDPTs above 4GB. */
+#define VMASST_TYPE_pae_extended_cr3     3
+
+/*
+ * x86 guests: Sane behaviour for virtual iopl
+ *  - virtual iopl updated from do_iret() hypercalls.
+ *  - virtual iopl reported in bounce frames.
+ *  - guest kernels assumed to be level 0 for the purpose of iopl checks.
+ */
+#define VMASST_TYPE_architectural_iopl   4
+
+/*
+ * All guests: activate update indicator in vcpu_runstate_info
+ * Enable setting the XEN_RUNSTATE_UPDATE flag in guest memory mapped
+ * vcpu_runstate_info during updates of the runstate information.
+ */
+#define VMASST_TYPE_runstate_update_flag 5
+
+/*
+ * x86/64 guests: strictly hide M2P from user mode.
+ * This allows the guest to control respective hypervisor behavior:
+ * - when not set, L4 tables get created with the respective slot blank,
+ *   and whenever the L4 table gets used as a kernel one the missing
+ *   mapping gets inserted,
+ * - when set, L4 tables get created with the respective slot initialized
+ *   as before, and whenever the L4 table gets used as a user one the
+ *   mapping gets zapped.
+ */
+#define VMASST_TYPE_m2p_strict           32
+
+#if __XEN_INTERFACE_VERSION__ < 0x00040600
+#define MAX_VMASST_TYPE                  3
+#endif
 
 /* Domain ids >= DOMID_FIRST_RESERVED cannot be used for ordinary domains. */
 #define DOMID_FIRST_RESERVED	xen_mk_uint(0x7FF0)
@@ -216,6 +632,32 @@ DEFINE_XEN_GUEST_HANDLE(xen_ulong_t);
 
 typedef uint16_t domid_t;
 
+/*
+ * Send an array of these to HYPERVISOR_mmu_update().
+ * NB. The fields are natural pointer/address size for this architecture.
+ */
+struct mmu_update {
+	uint64_t ptr;       /* Machine address of PTE. */
+	uint64_t val;       /* New contents of PTE.    */
+};
+typedef struct mmu_update mmu_update_t;
+DEFINE_XEN_GUEST_HANDLE(mmu_update_t);
+
+/*
+ * ` enum neg_errnoval
+ * ` HYPERVISOR_multicall(multicall_entry_t call_list[],
+ * `                      uint32_t nr_calls);
+ *
+ * NB. The fields are logically the natural register size for this
+ * architecture. In cases where xen_ulong_t is larger than this then
+ * any unused bits in the upper portion must be zero.
+ */
+struct multicall_entry {
+	xen_ulong_t op, result;
+	xen_ulong_t args[6];
+};
+typedef struct multicall_entry multicall_entry_t;
+DEFINE_XEN_GUEST_HANDLE(multicall_entry_t);
 #if __XEN_INTERFACE_VERSION__ < 0x00040400
 /*
  * Event channel endpoints per domain (when using the 2-level ABI):
@@ -372,13 +814,213 @@ struct shared_info {
 typedef struct shared_info shared_info_t;
 #endif
 
+/*
+ * `incontents 200 startofday Start-of-day memory layout
+ *
+ *  1. The domain is started within contiguous virtual-memory region.
+ *  2. The contiguous region ends on an aligned 4MB boundary.
+ *  3. This the order of bootstrap elements in the initial virtual region:
+ *      a. relocated kernel image
+ *      b. initial ram disk              [mod_start, mod_len]
+ *         (may be omitted)
+ *      c. list of allocated page frames [mfn_list, nr_pages]
+ *         (unless relocated due to XEN_ELFNOTE_INIT_P2M)
+ *      d. start_info_t structure        [register rSI (x86)]
+ *         in case of dom0 this page contains the console info, too
+ *      e. unless dom0: xenstore ring page
+ *      f. unless dom0: console ring page
+ *      g. bootstrap page tables         [pt_base and CR3 (x86)]
+ *      h. bootstrap stack               [register ESP (x86)]
+ *  4. Bootstrap elements are packed together, but each is 4kB-aligned.
+ *  5. The list of page frames forms a contiguous 'pseudo-physical' memory
+ *     layout for the domain. In particular, the bootstrap virtual-memory
+ *     region is a 1:1 mapping to the first section of the pseudo-physical map.
+ *  6. All bootstrap elements are mapped read-writable for the guest OS. The
+ *     only exception is the bootstrap page table, which is mapped read-only.
+ *  7. There is guaranteed to be at least 512kB padding after the final
+ *     bootstrap element. If necessary, the bootstrap virtual region is
+ *     extended by an extra 4MB to ensure this.
+ *
+ * Note: Prior to 25833:bb85bbccb1c9. ("x86/32-on-64 adjust Dom0 initial page
+ * table layout") a bug caused the pt_base (3.g above) and cr3 to not point
+ * to the start of the guest page tables (it was offset by two pages).
+ * This only manifested itself on 32-on-64 dom0 kernels and not 32-on-64 domU
+ * or 64-bit kernels of any colour. The page tables for a 32-on-64 dom0 got
+ * allocated in the order: 'first L1','first L2', 'first L3', so the offset
+ * to the page table base is by two pages back. The initial domain if it is
+ * 32-bit and runs under a 64-bit hypervisor should _NOT_ use two of the
+ * pages preceding pt_base and mark them as reserved/unused.
+ */
+#ifdef XEN_HAVE_PV_GUEST_ENTRY
+struct start_info {
+	/* THE FOLLOWING ARE FILLED IN BOTH ON INITIAL BOOT AND ON RESUME.    */
+	char magic[32];             /* "xen-<version>-<platform>".            */
+	unsigned long nr_pages;     /* Total pages allocated to this domain.  */
+	unsigned long shared_info;  /* MACHINE address of shared info struct. */
+	uint32_t flags;             /* SIF_xxx flags.                         */
+	xen_pfn_t store_mfn;        /* MACHINE page number of shared page.    */
+	uint32_t store_evtchn;      /* Event channel for store communication. */
+	union {
+		struct {
+			xen_pfn_t mfn;      /* MACHINE page number of console page.   */
+			uint32_t  evtchn;   /* Event channel for console page.        */
+		} domU;
+		struct {
+			uint32_t info_off;  /* Offset of console_info struct.         */
+			uint32_t info_size; /* Size of console_info struct from start.*/
+		} dom0;
+	} console;
+	/* THE FOLLOWING ARE ONLY FILLED IN ON INITIAL BOOT (NOT RESUME).     */
+	unsigned long pt_base;      /* VIRTUAL address of page directory.     */
+	unsigned long nr_pt_frames; /* Number of bootstrap p.t. frames.       */
+	unsigned long mfn_list;     /* VIRTUAL address of page-frame list.    */
+	unsigned long mod_start;    /* VIRTUAL address of pre-loaded module   */
+				    /* (PFN of pre-loaded module if           */
+				    /*  SIF_MOD_START_PFN set in flags).      */
+	unsigned long mod_len;      /* Size (bytes) of pre-loaded module.     */
+#define MAX_GUEST_CMDLINE 1024
+	int8_t cmd_line[MAX_GUEST_CMDLINE];
+	/* The pfn range here covers both page table and p->m table frames.   */
+	unsigned long first_p2m_pfn;/* 1st pfn forming initial P->M table.    */
+	unsigned long nr_p2m_frames;/* # of pfns forming initial P->M table.  */
+};
+typedef struct start_info start_info_t;
+
+/* New console union for dom0 introduced in 0x00030203. */
+#if __XEN_INTERFACE_VERSION__ < 0x00030203
+#define console_mfn    console.domU.mfn
+#define console_evtchn console.domU.evtchn
+#endif
+#endif /* XEN_HAVE_PV_GUEST_ENTRY */
+
+/* These flags are passed in the 'flags' field of start_info_t. */
+#define SIF_PRIVILEGED    (1<<0)  /* Is the domain privileged? */
+#define SIF_INITDOMAIN    (1<<1)  /* Is this the initial control domain? */
+#define SIF_MULTIBOOT_MOD (1<<2)  /* Is mod_start a multiboot module? */
+#define SIF_MOD_START_PFN (1<<3)  /* Is mod_start a PFN? */
+#define SIF_VIRT_P2M_4TOOLS (1<<4) /* Do Xen tools understand a virt. mapped */
+				   /* P->M making the 3 level tree obsolete? */
+#define SIF_PM_MASK       (0xFF<<8) /* reserve 1 byte for xen-pm options */
+
+/*
+ * A multiboot module is a package containing modules very similar to a
+ * multiboot module array. The only differences are:
+ * - the array of module descriptors is by convention simply at the beginning
+ *   of the multiboot module,
+ * - addresses in the module descriptors are based on the beginning of the
+ *   multiboot module,
+ * - the number of modules is determined by a termination descriptor that has
+ *   mod_start == 0.
+ *
+ * This permits to both build it statically and reference it in a configuration
+ * file, and let the PV guest easily rebase the addresses to virtual addresses
+ * and at the same time count the number of modules.
+ */
+struct xen_multiboot_mod_list {
+	/* Address of first byte of the module */
+	uint32_t mod_start;
+	/* Address of last byte of the module (inclusive) */
+	uint32_t mod_end;
+	/* Address of zero-terminated command line */
+	uint32_t cmdline;
+	/* Unused, must be zero */
+	uint32_t pad;
+};
+/*
+ * `incontents 200 startofday_dom0_console Dom0_console
+ *
+ * The console structure in start_info.console.dom0
+ *
+ * This structure includes a variety of information required to
+ * have a working VGA/VESA console.
+ */
+typedef struct dom0_vga_console_info {
+	uint8_t video_type; /* DOM0_VGA_CONSOLE_??? */
+#define XEN_VGATYPE_TEXT_MODE_3 0x03
+#define XEN_VGATYPE_VESA_LFB    0x23
+#define XEN_VGATYPE_EFI_LFB                                     0x70
+
+	union {
+		struct {
+			/* Font height, in pixels. */
+			uint16_t font_height;
+			/* Cursor location (column, row). */
+			uint16_t cursor_x, cursor_y;
+			/* Number of rows and columns (dimensions in characters). */
+			uint16_t rows, columns;
+		} text_mode_3;
+
+		struct {
+			/* Width and height, in pixels. */
+			uint16_t width, height;
+			/* Bytes per scan line. */
+			uint16_t bytes_per_line;
+			/* Bits per pixel. */
+			uint16_t bits_per_pixel;
+			/* LFB physical address, and size (in units of 64kB). */
+			uint32_t lfb_base;
+			uint32_t lfb_size;
+			/* RGB mask offsets and sizes, as defined by VBE 1.2+ */
+			uint8_t  red_pos, red_size;
+			uint8_t  green_pos, green_size;
+			uint8_t  blue_pos, blue_size;
+			uint8_t  rsvd_pos, rsvd_size;
+#if __XEN_INTERFACE_VERSION__ >= 0x00030206
+			/* VESA capabilities (offset 0xa, VESA command 0x4f00). */
+			uint32_t gbl_caps;
+			/* Mode attributes (offset 0x0, VESA command 0x4f01). */
+			uint16_t mode_attrs;
+			uint16_t pad;
+#endif
+#if __XEN_INTERFACE_VERSION__ >= 0x00040d00
+			/* high 32 bits of lfb_base */
+			uint32_t ext_lfb_base;
+#endif
+		} vesa_lfb;
+	} u;
+} dom0_vga_console_info_t;
+#define xen_vga_console_info dom0_vga_console_info
+#define xen_vga_console_info_t dom0_vga_console_info_t
 typedef uint8_t xen_domain_handle_t[16];
 
 __DEFINE_XEN_GUEST_HANDLE(uint8,  uint8_t);
 __DEFINE_XEN_GUEST_HANDLE(uint16, uint16_t);
 __DEFINE_XEN_GUEST_HANDLE(uint32, uint32_t);
 __DEFINE_XEN_GUEST_HANDLE(uint64, uint64_t);
+typedef struct {
+	uint8_t a[16];
+} xen_uuid_t;
 
+/*
+ * XEN_DEFINE_UUID(0x00112233, 0x4455, 0x6677, 0x8899,
+ *                 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff)
+ * will construct UUID 00112233-4455-6677-8899-aabbccddeeff presented as
+ * {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+ * 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
+ *
+ * NB: This is compatible with Linux kernel and with libuuid, but it is not
+ * compatible with Microsoft, as they use mixed-endian encoding (some
+ * components are little-endian, some are big-endian).
+ */
+#define XEN_DEFINE_UUID_(a, b, c, d, e1, e2, e3, e4, e5, e6)                \
+	{{((a) >> 24) & 0xFF, ((a) >> 16) & 0xFF,                           \
+	  ((a) >>  8) & 0xFF, ((a) >>  0) & 0xFF,                           \
+	  ((b) >>  8) & 0xFF, ((b) >>  0) & 0xFF,                           \
+	  ((c) >>  8) & 0xFF, ((c) >>  0) & 0xFF,                           \
+	  ((d) >>  8) & 0xFF, ((d) >>  0) & 0xFF,                           \
+		    e1, e2, e3, e4, e5, e6}}
+
+#if defined(__STDC_VERSION__) ? __STDC_VERSION__ >= 199901L : defined(__GNUC__)
+#define XEN_DEFINE_UUID(a, b, c, d, e1, e2, e3, e4, e5, e6)             \
+	((xen_uuid_t)XEN_DEFINE_UUID_(a, b, c, d, e1, e2, e3, e4, e5, e6))
+#else
+#define XEN_DEFINE_UUID(a, b, c, d, e1, e2, e3, e4, e5, e6)             \
+	XEN_DEFINE_UUID_(a, b, c, d, e1, e2, e3, e4, e5, e6)
+#endif /* __STDC_VERSION__ / __GNUC__ */
+
+#endif /* !__ASSEMBLY__ */
+
+/* Default definitions for macros used by domctl/sysctl. */
 #ifndef int64_aligned_t
 #define int64_aligned_t int64_t
 #endif
@@ -395,8 +1037,6 @@ struct xenctl_bitmap {
 	uint32_t nr_bits;
 };
 typedef struct xenctl_bitmap xenctl_bitmap_t;
-#endif
-
 #endif /* !__ASSEMBLY__ */
 
 #endif /* __XEN_PUBLIC_XEN_H__ */


### PR DESCRIPTION
Xen public headers are added to Zephyr kernel partially, so we need to update them for new features implementation.

Further implementation of Xen domains configuration and memory management requires dedicated Xen public headers inside Zephyr kernel. It will be used for add Zephyr OS Xen Domain-0 funtionalities.

Update existent and add new required public headers from Xen 4.19.0 release.