### PR TITLE
boards: arm: rz_a2m: update cloning instructions in rel notes

### DIFF
--- a/boards/arm/rz_a2m/release_notes/rza2m_release_notes.tex
+++ b/boards/arm/rz_a2m/release_notes/rza2m_release_notes.tex
@@ -32,7 +32,7 @@
 
 \title{RZ/A2M for Zephyr Release Notes v1.0}
 \author{EPAM Systems}
-\date{December, 2023}
+\date{April, 2024}
 
 \maketitle
 
@@ -70,10 +70,8 @@ west init -m git@github.com:xen-troops/zephyr.git --mr rza2m-release-1.0 zephyr_
 cd zephyr_rza2m/zephyr
 \end{lstlisting}
 
-Cloning GIT repo for the first time requires SSH keys to be
-registration. Please follow this guide for the detailed instructions:
-
-\url{https://gitbud.epam.com/help/user/ssh.md}
+The detailed instructions for cloning a repository can be found at the following link:
+\url{https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository}
 
 \section{Board initial configuration}\label{board-initial-configuration}
 
@@ -3612,6 +3610,10 @@ Current project status can be got from Jira Project:
 	28 Dec 2023 & & Add wm8978 codec sample \\
 	\hline
 	28 Dec 2023 & 0.2 & Update release to v0.2 \\
+	\hline
+	3 Apr 2024 & 1.0 & Update release to v1.0 \\
+	\hline
+	17 Apr 2024 & & Update clone documentation link \\
 	\hline
 \end{tabular}
 


### PR DESCRIPTION
The link for ssh keys registration is still pointing on gitbud while the main repository is on github. Updated link to the GitHub documentation.