### PR TITLE
xen: domctl: Get back created domain id

### DIFF
--- a/drivers/xen/dom0/domctl.c
+++ b/drivers/xen/dom0/domctl.c
@@ -272,15 +272,23 @@ int xen_domctl_max_vcpus(int domid, int max_vcpus)
 	return do_domctl(&domctl);
 }
 
-int xen_domctl_createdomain(int domid, struct xen_domctl_createdomain *config)
+int xen_domctl_createdomain(int *domid, struct xen_domctl_createdomain *config)
 {
-	xen_domctl_t domctl = {
-		.cmd = XEN_DOMCTL_createdomain,
-		.domain = domid,
-		.u.createdomain = *config,
-	};
+	int ret;
+	xen_domctl_t domctl;
 
-	return do_domctl(&domctl);
+	if (!domid || !config) {
+		return -EINVAL;
+	}
+
+	domctl.cmd = XEN_DOMCTL_createdomain,
+	domctl.domain = *domid,
+	domctl.u.createdomain = *config,
+
+	ret = do_domctl(&domctl);
+	*domid = domctl.domain;
+
+	return ret;
 }
 
 int xen_domctl_destroydomain(int domid)

--- a/include/zephyr/xen/dom0/domctl.h
+++ b/include/zephyr/xen/dom0/domctl.h
@@ -187,11 +187,15 @@ int xen_domctl_max_vcpus(int domid, int max_vcpus);
 /**
  * @brief Creates a new domain with the specified domain ID and configuration.
  *
- * @param domid The domain ID of the new domain.
+ * NB. domid is an IN/OUT parameter for this operation.
+ * If it is specified as an invalid value (0 or >= DOMID_FIRST_RESERVED),
+ * an id is auto-allocated and returned.
+
+ * @param[in,out] domid Pointer to domain ID of the new domain.
  * @param config Pointer to a structure containing the configuration for the new domain.
  * @return 0 on success, or a negative error code on failure.
  */
-int xen_domctl_createdomain(int domid, struct xen_domctl_createdomain *config);
+int xen_domctl_createdomain(int *domid, struct xen_domctl_createdomain *config);
 
 /**
  * @brief Clean and invalidate caches associated with given region of


### PR DESCRIPTION
If 0 is passed as domain id to the Xen createdomain hypercall, it will allocate a new domain id and return it via the domctl structure. Allow callers to access this new domain id via a pointer arg. This will allow to create domains without explicitly specifying the domain id for them.