### PR TITLE
rpi5: fix build of dom0 app

### DIFF
--- a/drivers/xen/dom0/domctl.c
+++ b/drivers/xen/dom0/domctl.c
@@ -272,15 +272,23 @@ int xen_domctl_max_vcpus(int domid, int max_vcpus)
 	return do_domctl(&domctl);
 }
 
-int xen_domctl_createdomain(int domid, struct xen_domctl_createdomain *config)
+int xen_domctl_createdomain(int *domid, struct xen_domctl_createdomain *config)
 {
-	xen_domctl_t domctl = {
-		.cmd = XEN_DOMCTL_createdomain,
-		.domain = domid,
-		.u.createdomain = *config,
-	};
+	int ret;
+	xen_domctl_t domctl;
 
-	return do_domctl(&domctl);
+	if (!domid || !config) {
+		return -EINVAL;
+	}
+
+	domctl.cmd = XEN_DOMCTL_createdomain,
+	domctl.domain = *domid,
+	domctl.u.createdomain = *config,
+
+	ret = do_domctl(&domctl);
+	*domid = domctl.domain;
+
+	return ret;
 }
 
 int xen_domctl_destroydomain(int domid)

--- a/include/zephyr/xen/dom0/domctl.h
+++ b/include/zephyr/xen/dom0/domctl.h
@@ -187,11 +187,15 @@ int xen_domctl_max_vcpus(int domid, int max_vcpus);
 /**
  * @brief Creates a new domain with the specified domain ID and configuration.
  *
- * @param domid The domain ID of the new domain.
+ * NB. domid is an IN/OUT parameter for this operation.
+ * If it is specified as an invalid value (0 or >= DOMID_FIRST_RESERVED),
+ * an id is auto-allocated and returned.
+
+ * @param[in,out] domid Pointer to domain ID of the new domain.
  * @param config Pointer to a structure containing the configuration for the new domain.
  * @return 0 on success, or a negative error code on failure.
  */
-int xen_domctl_createdomain(int domid, struct xen_domctl_createdomain *config);
+int xen_domctl_createdomain(int *domid, struct xen_domctl_createdomain *config);
 
 /**
  * @brief Clean and invalidate caches associated with given region of


### PR DESCRIPTION
commit dbe6b2c ("xen-dom-mgmt: Get back the domain id from xen_domctl_createdomain") went xenlib

commit eb0ed211274 ("xen: domctl: Get back created domain id") went zephyr-v3.6.0-xt

The above commit is also required for rpi 5 - so cherry-pick it to fix the build.
