### PR TITLE
HACK: include: xen: public: hvm: add HVM_PARAM_MAGIC_BASE_PFN key in hvm

### DIFF
--- a/include/zephyr/xen/public/hvm/params.h
+++ b/include/zephyr/xen/public/hvm/params.h
@@ -33,6 +33,7 @@
  */
 #define HVM_PARAM_STORE_PFN		1
 #define HVM_PARAM_STORE_EVTCHN		2
+#define HVM_PARAM_MAGIC_BASE_PFN	3
 
 /* Console debug shared memory ring and event channel */
 #define HVM_PARAM_CONSOLE_PFN		17


### PR DESCRIPTION
Add a new HVMOP key HVM_PARAM_MAGIC_BASE_PFN for storing the magic page region base PFN. The value will be set at Dom0less DomU construction time after Dom0less DomU's magic page region has been allocated.

HACK. to indicate that Xen upstream work is in progress and things may change.

[1] https://patchew.org/Xen/20240426031455.579637-1-xin.wang2@amd.com/20240426031455.579637-3-xin.wang2@amd.com/
Signed-off-by: Grygorii Strashko <grygorii_strashko@epam.com>