### PR TITLE
boards: arm: rz_g3s: Fix typo in the Release Notes

### DIFF
--- a/boards/arm/rz_g3s/doc/delivery/delivery_scope.rst
+++ b/boards/arm/rz_g3s/doc/delivery/delivery_scope.rst
@@ -4,4 +4,4 @@ Scope of delivery
 The release includes the following items:
 
 * This Release Notes.
-* Zephyr repository with the source code set of drivers for RZ/A2M support integrated.
+* Zephyr repository with the source code set of drivers for RZ/G3S support integrated.

--- a/boards/arm/rz_g3s/doc/pwm/GPT.rst
+++ b/boards/arm/rz_g3s/doc/pwm/GPT.rst
@@ -36,7 +36,7 @@ The RZ G3S PWM driver code can be found at:
 
 .. code-block:: text
 
-    drivers/pwm/pwm_rz2am.c
+    drivers/pwm/pwm_rza2m.c
 
 This driver is compatible with RZ/A2M driver so the implementation is shared.
 


### PR DESCRIPTION
Fix minor typo in the Release notes. The following changes were made:
- Scope of delivery - change board name to RZ/G3S;
- GPT support - correct the  pwm driver filename.