### PR TITLE
Remove hypervisor and ram nodes from Dom0 snippet

### DIFF
--- a/snippets/xen_dom0/README.rst
+++ b/snippets/xen_dom0/README.rst
@@ -36,6 +36,51 @@ Xen control domain example. To run such setup, you need to:
 * take and compile sample device tree from `example/` directory
 * build your Zephyr sample/application with `xen_dom0` snippet and start it as Xen control domain
 
+**Important notice regarding device tree**
+
+Xen allocates addresses used for Dom0 image and grant tables/extended regions dynamically so they
+may differs on specific setups (they depends on memory banks location and size, application
+image size, hypervisor load address used by bootloader etc.). Since Zephyr does not parse device
+tree in runtime and is not a position independent executable, it needs to know exact values on
+build time. To make it you need to build your final binary, try to boot it with Xen and analyze
+hypervisor output to get exact addesses for your setup. They will look as follows:
+
+Grant table region (first reg in hypervisor node):
+
+.. code-block:: console
+
+    (XEN) Grant table range: 0x00000088080000-0x000000880c0000
+
+Extended regions (2nd and further regs in hypervisor node):
+
+.. code-block:: console
+
+    (XEN) [    0.928173] d0: extended region 2: 0x40000000->0x47e00000
+
+Zephyr Dom0 memory:
+
+.. code-block:: console
+
+    (XEN) Allocating 1:1 mappings for dom0:
+    (XEN) BANK[0] 0x00000060000000-0x00000070000000 (256MB)
+
+Device tree nodes, that should be added by application overlay for provided example:
+
+.. code-block:: devicetree
+
+    hypervisor: hypervisor@88080000 {
+        compatible = "xen,xen";
+        reg = <0x0 0x88080000 0x0 0x40000 0x0 0x40000000 0x0 0x7e00000>;
+        interrupts = <GIC_PPI 0x0 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+        interrupt-parent = <&gic>;
+        status = "okay";
+    };
+
+    ram: memory@60000000 {
+        device_type = "mmio-sram";
+        reg = <0x00 0x60000000 0x00 DT_SIZE_M(256)>;
+    };
+
 For starting you can use QEMU from Zephyr SDK by following command:
 
 .. code-block:: console

--- a/snippets/xen_dom0/boards/qemu_cortex_a53.overlay
+++ b/snippets/xen_dom0/boards/qemu_cortex_a53.overlay
@@ -4,46 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &sram0;
-
 &uart0 {
 	/* Xen consoleio will be used */
 	status = "disabled";
-};
-
-/ {
-	/*
-	 * This node may differs on different setups, please check
-	 * following line in Xen boot log to set it right:
-	 * (XEN) Grant table range: 0x00000040200000-0x00000040240000
-	 * Also, add extended region 1:
-	 * (XEN) Extended region 1: 0x40000000->0x47e00000
-	 *
-	 * Xen passes actual values for setup in domain device tree, but Zephyr
-	 * is not capable to parse and handle it in runtime.
-	 */
-	hypervisor: hypervisor@40200000 {
-		compatible = "xen,xen";
-		reg = <0x0 0x40200000 0x0 0x40000 0x0 0x40400000 0x0 0x17C00000>;
-		interrupts = <GIC_PPI 0x0 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
-		interrupt-parent = <&gic>;
-		status = "okay";
-	};
-
-	/*
-	 * This node may differs on different setups, because Xen picks
-	 * region for Domain-0 for every specific configuration. You can
-	 * start Xen for your platform and check following log:
-	 * (XEN) Allocating 1:1 mappings for dom0:
-	 * (XEN) BANK[0] 0x00000058000000-0x00000060000000 (128MB)
-	 *
-	 * Xen passes actual values for setup in domain device tree, but Zephyr
-	 * is not capable to parse and handle it in runtime.
-	 */
-	soc {
-		sram0: memory@58000000 {
-			device_type = "mmio-sram";
-			reg = <0x00 0x58000000 0x00 DT_SIZE_M(128)>;
-		};
-	};
 };

--- a/snippets/xen_dom0/boards/rcar_h3ulcb_ca57.overlay
+++ b/snippets/xen_dom0/boards/rcar_h3ulcb_ca57.overlay
@@ -4,40 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &ram;
 /delete-node/ &scif2;
-
-/ {
-	/*
-	 * This node may differs on different setups, please check
-	 * following line in Xen boot log to set it right:
-	 * (XEN) Grant table range: 0x00000088080000-0x000000880c0000
-	 * Also, add extended region 2:
-	 * (XEN) [    0.928173] d0: extended region 2: 0x40000000->0x47e00000
-	 *
-	 * Xen passes actual values for setup in domain device tree, but Zephyr
-	 * is not capable to parse and handle it in runtime.
-	 */
-	hypervisor: hypervisor@88080000 {
-		compatible = "xen,xen";
-		reg = <0x0 0x88080000 0x0 0x40000 0x0 0x40000000 0x0 0x7e00000>;
-		interrupts = <GIC_PPI 0x0 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
-		interrupt-parent = <&gic>;
-		status = "okay";
-	};
-
-	/*
-	 * This node may differs on different setups, because Xen picks
-	 * region for Domain-0 for every specific configuration. You can
-	 * start Xen for your platform and check following log:
-	 * (XEN) Allocating 1:1 mappings for dom0:
-	 * (XEN) BANK[0] 0x00000060000000-0x00000070000000 (256MB)
-	 *
-	 * Xen passes actual values for setup in domain device tree, but Zephyr
-	 * is not capable to parse and handle it in runtime.
-	 */
-	ram: memory@60000000 {
-		device_type = "mmio-sram";
-		reg = <0x00 0x60000000 0x00 DT_SIZE_M(256)>;
-	};
-};

--- a/snippets/xen_dom0/boards/rcar_salvator_xs_m3.overlay
+++ b/snippets/xen_dom0/boards/rcar_salvator_xs_m3.overlay
@@ -4,40 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &ram;
 /delete-node/ &scif2;
-
-/ {
-	/*
-	 * This node may differs on different setups, please check
-	 * following line in Xen boot log to set it right:
-	 * (XEN) Grant table range: 0x00000088080000-0x000000880c0000
-	 * Also, add extended region 2:
-	 * (XEN) [    0.928173] d0: extended region 2: 0x40000000->0x47e00000
-	 *
-	 * Xen passes actual values for setup in domain device tree, but Zephyr
-	 * is not capable to parse and handle it in runtime.
-	 */
-	hypervisor: hypervisor@88080000 {
-		compatible = "xen,xen";
-		reg = <0x0 0x88080000 0x0 0x40000 0x0 0x40000000 0x0 0x7e00000>;
-		interrupts = <GIC_PPI 0x0 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
-		interrupt-parent = <&gic>;
-		status = "okay";
-	};
-
-	/*
-	 * This node may differs on different setups, because Xen picks
-	 * region for Domain-0 for every specific configuration. You can
-	 * start Xen for your platform and check following log:
-	 * (XEN) Allocating 1:1 mappings for dom0:
-	 * (XEN) BANK[0] 0x00000060000000-0x00000070000000 (256MB)
-	 *
-	 * Xen passes actual values for setup in domain device tree, but Zephyr
-	 * is not capable to parse and handle it in runtime.
-	 */
-	ram: memory@60000000 {
-		device_type = "mmio-sram";
-		reg = <0x00 0x60000000 0x00 DT_SIZE_M(256)>;
-	};
-};

--- a/snippets/xen_dom0/boards/rcar_spider_ca55.overlay
+++ b/snippets/xen_dom0/boards/rcar_spider_ca55.overlay
@@ -4,40 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &ram;
 /delete-node/ &hscif0;
-
-/ {
-	/*
-	 * This node may differs on different setups, please check
-	 * following line in Xen boot log to set it right:
-	 * (XEN) Grant table range: 0x00000078080000-0x000000780c0000
-	 * Also, add extended region 1:
-	 * (XEN) Extended region 1: 0x40000000->0x47e00000
-	 *
-	 * Xen passes actual values for setup in domain device tree, but Zephyr
-	 * is not capable to parse and handle it in runtime.
-	 */
-	hypervisor: hypervisor@78080000 {
-		compatible = "xen,xen";
-		reg = <0x0 0x78080000 0x0 0x40000 0x0 0x40000000 0x0 0x7e00000>;
-		interrupts = <GIC_PPI 0x0 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
-		interrupt-parent = <&gic>;
-		status = "okay";
-	};
-
-	/*
-	 * This node may differs on different setups, because Xen picks
-	 * region for Domain-0 for every specific configuration. You can
-	 * start Xen for your platform and check following log:
-	 * (XEN) Allocating 1:1 mappings for dom0:
-	 * (XEN) BANK[0] 0x00000080000000-0x00000090000000 (256MB)
-	 *
-	 * Xen passes actual values for setup in domain device tree, but Zephyr
-	 * is not capable to parse and handle it in runtime.
-	 */
-	ram: memory@80000000 {
-		device_type = "mmio-sram";
-		reg = <0x00 0x80000000 0x00 DT_SIZE_M(256)>;
-	};
-};


### PR DESCRIPTION
Snippets are applied at the end of device tree generation which makes impossible to edit some values by application. Thus, we need to remove hypervisor and ram nodes from them, to allow application set correct regions.

UPD: CI fails due to long commit topics, that contain subsystem tag and board names.