### PR TITLE
pytest: add "--skip-flash" option

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_adapter.py
@@ -74,7 +74,7 @@ class DeviceAdapter(abc.ABC):
         self._start_reader_thread()
         self.connect()
 
-        if self.device_config.type == 'hardware':
+        if not self.device_config.skip_flash and self.device_config.type == 'hardware':
             # On hardware, flash after connecting to COM port, otherwise some messages
             # from target can be lost.
             self._flash_and_run()

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
@@ -105,6 +105,12 @@ def pytest_addoption(parser: pytest.Parser):
         choices=('function', 'class', 'module', 'package', 'session'),
         help='The scope for which `dut` and `shell` fixtures are shared.'
     )
+    twister_harness_group.addoption(
+        '--skip-flash',
+        default=False,
+        help='Skip flashing.',
+        action='store_true',
+    )
 
 
 def pytest_configure(config: pytest.Config):

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
@@ -30,6 +30,7 @@ class DeviceConfig:
     pre_script: Path | None = None
     post_script: Path | None = None
     post_flash_script: Path | None = None
+    skip_flash: bool = False
 
 
 @dataclass
@@ -61,6 +62,7 @@ class TwisterHarnessConfig:
             pre_script=_cast_to_path(config.option.pre_script),
             post_script=_cast_to_path(config.option.post_script),
             post_flash_script=_cast_to_path(config.option.post_flash_script),
+            skip_flash=config.option.skip_flash,
         )
 
         devices.append(device_from_cli)


### PR DESCRIPTION
The pytest is always trying to flash when running on real HW (--device-type=hardware). On ARM64 Cortex-A platform like RPI5 there no way to implement flashing through pytest framework now: the Zephyr binary has to be stored on SD-card and loaded by bootloader.

Add "--skip-flash" option which still will allow to run pytest with shell interface manually after platform is booted and shell is ready.