### PR TITLE
drivers: xen: gnttab: process gentabs in reverse order

### DIFF
--- a/drivers/xen/gnttab.c
+++ b/drivers/xen/gnttab.c
@@ -343,12 +343,12 @@ static int gnttab_init(void)
 		put_free_entry(gref);
 	}
 
-	for (i = 0; i < NR_GRANT_FRAMES; i++) {
+	for (i = NR_GRANT_FRAMES; i; i--) {
 		xatp.domid = DOMID_SELF;
 		xatp.size = 0;
 		xatp.space = XENMAPSPACE_grant_table;
-		xatp.idx = i;
-		xatp.gpfn = xen_virt_to_gfn(Z_TOPLEVEL_ROM_NAME(grant_tables).phys_addr) + i;
+		xatp.idx = i - 1;
+		xatp.gpfn = xen_virt_to_gfn(Z_TOPLEVEL_ROM_NAME(grant_tables).phys_addr) + (i - 1);
 		rc = HYPERVISOR_memory_op(XENMEM_add_to_physmap, &xatp);
 		__ASSERT(!rc, "add_to_physmap failed; status = %d\n", rc);
 	}


### PR DESCRIPTION
The Xen extends domain gentab region every time domain requests gentab basing on gentab idx. If idx > xen_current_max_gentab_idx the Xen extends number of gentabs so that idx <= xen_current_max_gentab_idx. As result now when gentabs are requested from gentab low_idx to max_idx Xen is performing gentab extension by 1 and the bunch of log messages is produced:

(XEN) xen-source/xen/common/grant_table.c:1909:d0v0 Expanding d0 \
  grant table from 1 to 2 frames

This patch changes gentab processing from gentab max_idx to low_idx which allows Xen to perform gentab extension only once (to max_idx) and only one message will be produced in the log:

(XEN) xen-source/xen/common/grant_table.c:1909:d0v0 Expanding d0 \
  grant table from 1 to 64 frames