### PR TITLE
subsys: coverage: fix arm64 build with gcov enabled

### DIFF
--- a/subsys/testsuite/coverage/coverage_ram.ld
+++ b/subsys/testsuite/coverage/coverage_ram.ld
@@ -6,7 +6,7 @@
 
 /* Copied from linker.ld */
 
-#ifdef CONFIG_ARM
+#if defined(CONFIG_ARM) || defined(CONFIG_ARM64)
 SECTION_DATA_PROLOGUE(_GCOV_BSS_SECTION_NAME,(NOLOAD),)
 {
 #ifdef CONFIG_USERSPACE


### PR DESCRIPTION
On ARM64 the build will fail with coverage and GCOV enabled:

  CONFIG_COVERAGE=y
  CONFIG_COVERAGE_GCOV=y
  CONFIG_FORCE_COVERAGE=y

 west build -b rcar_spider_ca55 -p always zephyr-dom0-xt \
 -S xen_dom0  -- -DCONFIG_COVERAGE=y -DCONFIG_FORCE_COVERAGE=y

Failure:
 "linker_zephyr_pre0.cmd:181: undefined symbol `__gcov_bss_end' referenced
in expression"

Fix build of ARM64 platforms with coverage and GCOV enabled.