### PR TITLE
drivers: sdhc: sdhci_common: fix sd write

### DIFF
--- a/drivers/sdhc/sdhci_common.c
+++ b/drivers/sdhc/sdhci_common.c
@@ -593,7 +593,7 @@ static int sdhci_send_cmd(struct sdhci_common *sdhci_ctx, struct sdhc_command *c
 int sdhci_send_req(struct sdhci_common *sdhci_ctx, struct sdhc_command *cmd, struct sdhc_data *data)
 {
 	uint32_t reg_present_state;
-	bool is_read;
+	bool is_read = false;
 	int ret = 0;
 
 	reg_present_state = sys_read32(sdhci_ctx->reg_base + SDHCI_PRESENT_STATE);


### PR DESCRIPTION
The SD write operation fail is observed because the is_read flag is not initialized properly and, as result got value from stack. This causes Write operation to be performed with is_read == true and so to fail.

Fix it by initializing is_read properly to false.