### PR TITLE
Rpi5: mmc add adma support

### DIFF
--- a/drivers/sdhc/Kconfig.brcm
+++ b/drivers/sdhc/Kconfig.brcm
@@ -21,7 +21,7 @@ config SDHC_BUFFER_ALIGNMENT
 
 choice BRCM_BCM2712_XFER_MODE
 	bool "Select BCM2712 SDHC (SD/MMC) data transfer mode"
-	default BRCM_BCM2712_XFER_SDMA
+	default BRCM_BCM2712_XFER_ADMA2
 
 config BRCM_BCM2712_XFER_PIO
 	bool "BCM2712 SDHC PIO data transfer mode"
@@ -29,6 +29,14 @@ config BRCM_BCM2712_XFER_PIO
 config BRCM_BCM2712_XFER_SDMA
 	bool "BCM2712 SDHC SDMA data transfer mode"
 
+config BRCM_BCM2712_XFER_ADMA2
+	bool "BCM2712 SDHC ADMA2 data transfer mode"
+
 endchoice
+
+config BRCM_BCM2712_ADMA2_DESCS_NUM
+	int "BCM2712 SDHC ADMA number of descriptors"
+	default 16 if BRCM_BCM2712_XFER_ADMA2
+	default 0
 
 endif # BRCM_BCM2712_SDHCI

--- a/drivers/sdhc/Kconfig.sdhc
+++ b/drivers/sdhc/Kconfig.sdhc
@@ -7,3 +7,12 @@ config SDHCI_GENERIC
 	help
 	  SD Host Controller (SDHC) generic implementation module according to
 	  SD Host Controller Standard Specification (Version 3.0).
+
+config SDHCI_GENERIC_ADMA2_DESC_MAX_LEN
+	int "ADMA2 max xfer size per descriptor"
+	default 65532
+	range 1 65536
+	help
+	  Defines ADMA2 max xfer size per descriptor. The default value selected by
+	  taking into account that some SDHC HW implemtations may not handle
+	  properly descriptor "Length Field" == 0 case (65536 bytes xfer).


### PR DESCRIPTION
This PR enables ADMA2 support for rpi5 SDHC controller.
The ADMA2 is enabled by default.