### PR TITLE
Rpi5 enable sdhc irq support

### DIFF
--- a/drivers/sdhc/Kconfig.brcm
+++ b/drivers/sdhc/Kconfig.brcm
@@ -11,7 +11,7 @@ config BRCM_BCM2712_SDHCI
 	select CACHE_MANAGEMENT
 	select SDHC_SUPPORTS_UHS if SDMMC_STACK
 	help
-	  BCM2712 SDHC v3.0 cpapable.
+	  BCM2712 SDHC v3.0 capable with SD interface support.
 
 if BRCM_BCM2712_SDHCI
 
@@ -38,5 +38,12 @@ config BRCM_BCM2712_ADMA2_DESCS_NUM
 	int "BCM2712 SDHC ADMA number of descriptors"
 	default 16 if BRCM_BCM2712_XFER_ADMA2
 	default 0
+
+config BRCM_BCM2712_SDHC_USE_IRQ
+	bool "BCM2712 SDHC enable IRQ support"
+	select EVENTS
+	default y
+	help
+	  BCM2712 SDHC enable IRQ support for cmd/data transfers.
 
 endif # BRCM_BCM2712_SDHCI

--- a/drivers/sdhc/brcm_bcm2712_sdhci.c
+++ b/drivers/sdhc/brcm_bcm2712_sdhci.c
@@ -49,6 +49,7 @@ struct bcm2712_sdhci_config {
 	const struct device *regulator_vqmmc;
 	const struct device *regulator_vmmc;
 	uint32_t clk_freq;
+	void (*irq_config)(const struct device *dev);
 
 	struct sdhc_adma_desc *adma_descs;
 
@@ -348,6 +349,10 @@ use_dt_freq:
 		LOG_DEV_ERR(dev, "enable sdma");
 	}
 
+	if (IS_ENABLED(CONFIG_BRCM_BCM2712_SDHC_USE_IRQ)) {
+		sdhc_enable_irq(sdhci_ctx, true);
+	}
+
 	return ret;
 }
 
@@ -450,8 +455,35 @@ static int bcm2712_sdhci_init(const struct device *dev)
 		}
 	}
 
+	if (IS_ENABLED(CONFIG_BRCM_BCM2712_SDHC_USE_IRQ)) {
+		cfg->irq_config(dev);
+	}
+
 	return 0;
 }
+
+#if defined(CONFIG_BRCM_BCM2712_SDHC_USE_IRQ)
+static void bcm2712_irq_handler(const void *arg)
+{
+	const struct device *dev = arg;
+	struct bcm2712_sdhci_data *data = dev->data;
+
+	sdhc_irq_cb(&data->sdhci_ctx);
+}
+
+#define BCM2712_SDHC_IRQ_CFG(inst)                                                                 \
+	static void irq_config_##inst(const struct device *dev)                                    \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(inst), DT_INST_IRQ(inst, priority), bcm2712_irq_handler,  \
+			    DEVICE_DT_INST_GET(inst), DT_INST_IRQ(inst, flags));                   \
+		irq_enable(DT_INST_IRQN(inst));                                                    \
+	}
+
+#define BCM2712_SDHC_IRQ_INIT(inst) .irq_config = irq_config_##inst,
+#else
+#define BCM2712_SDHC_IRQ_CFG(inst)
+#define BCM2712_SDHC_IRQ_INIT(inst)
+#endif /* CONFIG_BRCM_BCM2712_SDHC_USE_IRQ */
 
 #if defined(CONFIG_BRCM_BCM2712_XFER_ADMA2)
 #define BRCM_BCM2712_ADMA2_DESCS(inst)                                                             \
@@ -465,6 +497,7 @@ static int bcm2712_sdhci_init(const struct device *dev)
 
 #define BCM2712_SDHCI_INIT(inst)                                                                   \
 	BRCM_BCM2712_ADMA2_DESCS(inst)                                                             \
+	BCM2712_SDHC_IRQ_CFG(inst)                                                                 \
 	static const struct bcm2712_sdhci_config bcm2712_sdhci_config_##inst = {                   \
 		DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(host, DT_DRV_INST(inst)),                       \
 		DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(cfg, DT_DRV_INST(inst)),                        \
@@ -483,6 +516,7 @@ static int bcm2712_sdhci_init(const struct device *dev)
 		.power_delay_ms = DT_INST_PROP_OR(inst, power_delay_ms, 500),                      \
 		.non_removable = DT_INST_PROP_OR(inst, non_removable, 0),                          \
 		BRCM_BCM2712_ADMA2_DESCS_INIT(inst)                                                \
+		BCM2712_SDHC_IRQ_INIT(inst)                                                        \
 	};                                                                                         \
 	static struct bcm2712_sdhci_data bcm2712_sdhci_data_##inst = {};                           \
 	DEVICE_DT_INST_DEFINE(inst, &bcm2712_sdhci_init, NULL, &bcm2712_sdhci_data_##inst,         \

--- a/drivers/sdhc/brcm_bcm2712_sdhci.c
+++ b/drivers/sdhc/brcm_bcm2712_sdhci.c
@@ -75,12 +75,15 @@ static int bcm2712_sdhci_request(const struct device *dev, struct sdhc_command *
 				 struct sdhc_data *sd_data)
 {
 	struct bcm2712_sdhci_data *data = dev->data;
+	unsigned int retry = cmd->retries;
 	int ret;
 
-	ret = sdhci_send_req(&data->sdhci_ctx, cmd, sd_data);
-	if (ret) {
-		LOG_DEV_ERR(dev, "sd cmd request failed (%d)", ret);
-	}
+	do {
+		ret = sdhci_send_req(&data->sdhci_ctx, cmd, sd_data);
+		if (ret) {
+			LOG_DEV_ERR(dev, "sd cmd request failed (%d)", ret);
+		}
+	} while (ret != 0 && retry--);
 	return ret;
 }
 

--- a/drivers/sdhc/sdhci_common.c
+++ b/drivers/sdhc/sdhci_common.c
@@ -362,13 +362,40 @@ static int sdhci_poll_data_complete(struct sdhci_common *sdhci_ctx, int32_t time
 	}
 
 	if (reg_normal_int_stat & SDHCI_INT_ERROR) {
-		LOG_ERR("sdhc:req: data xfer error int_status:%08x", reg_normal_int_stat);
+		LOG_ERR("sdhc:req: data(poll) xfer error int_status:%08x", reg_normal_int_stat);
 		sys_write32(SDHCI_INT_ERROR_MASK, sdhci_ctx->reg_base + SDHCI_INT_STATUS);
 		ret = -EIO;
 	}
 
 	if (!timeout) {
-		LOG_ERR("sdhc:req: data xfer timeout int_status:%08x", reg_normal_int_stat);
+		LOG_ERR("sdhc:req: data(poll) xfer timeout int_status:%08x", reg_normal_int_stat);
+	}
+
+	return ret;
+}
+
+static int sdhci_wait_data_complete(struct sdhci_common *sdhci_ctx, uint32_t timeout)
+{
+	k_timeout_t wait_time;
+	uint32_t events;
+	int ret = 0;
+
+	if (timeout == SDHC_TIMEOUT_FOREVER) {
+		wait_time = K_FOREVER;
+	} else {
+		wait_time = K_MSEC(timeout);
+	}
+
+	events = k_event_wait(&sdhci_ctx->irq_event,
+			      SDHCI_INT_XFER_COMPLETE | SDHCI_INT_ERROR,
+			      false, wait_time);
+
+	if (events & SDHCI_INT_ERROR) {
+		LOG_ERR("sdhc:req: data(irq) xfer error int_status:%08x", events);
+		ret = -EIO;
+	} else if (!events) {
+		LOG_ERR("sdhc:req: data(irq) xfer timeout");
+		ret = -ETIMEDOUT;
 	}
 
 	return ret;
@@ -431,6 +458,48 @@ static int sdhci_transfer_data(struct sdhci_common *sdhci_ctx, struct sdhc_data 
 	}
 
 	return sdhci_poll_data_complete(sdhci_ctx, timeout / 100);
+}
+
+static int sdhci_transfer_data_irq(struct sdhci_common *sdhci_ctx, struct sdhc_data *data,
+				   bool is_read)
+{
+	uint8_t *data_ptr = data->data;
+	uint32_t block = data->blocks;
+	k_timeout_t wait_time;
+	uint32_t rdy_mask;
+	uint32_t events;
+
+	if (data->timeout_ms == SDHC_TIMEOUT_FOREVER) {
+		wait_time = K_FOREVER;
+	} else {
+		wait_time = K_MSEC(data->timeout_ms);
+	}
+
+	rdy_mask = SDHCI_INT_ERROR;
+	if (is_read) {
+		rdy_mask |= SDHCI_INT_BUF_RD_READY;
+	} else {
+		rdy_mask |= SDHCI_INT_BUF_WR_READY;
+	}
+
+	while (block) {
+		events = k_event_wait(&sdhci_ctx->irq_event, rdy_mask,
+				      false, wait_time);
+
+		if (events & SDHCI_INT_ERROR) {
+			LOG_ERR("sdhc:req: data(irq) io xfer error int_status:%08x", events);
+			return -EIO;
+		} else if (!events) {
+			LOG_ERR("sdhc:req: data(irq) io xfer timeout");
+			return -ETIMEDOUT;
+		}
+		k_event_clear(&sdhci_ctx->irq_event, rdy_mask);
+		sdhci_data_port_io(sdhci_ctx, data_ptr, data->block_size, is_read);
+		data_ptr += data->block_size;
+		block--;
+	};
+
+	return sdhci_wait_data_complete(sdhci_ctx, data->timeout_ms);
 }
 
 static void sdhc_adma_desc_fill(struct sdhc_adma_desc *desc, uintptr_t dma_addr, uint16_t len,
@@ -635,13 +704,40 @@ static int sdhci_poll_cmd_complete(struct sdhci_common *sdhci_ctx, int32_t timeo
 	}
 
 	if (reg_normal_int_stat & SDHCI_INT_ERROR) {
-		LOG_ERR("sdhc:req: cmd error int_status:%08x", reg_normal_int_stat);
+		LOG_ERR("sdhc:req: cmd(poll) error int_status:%08x", reg_normal_int_stat);
 		sys_write32(SDHCI_INT_ERROR_MASK, sdhci_ctx->reg_base + SDHCI_INT_STATUS);
 		ret = -EIO;
 	}
 
 	if (!timeout) {
-		LOG_ERR("sdhc:req: cmd timeout int_status:%08x", reg_normal_int_stat);
+		LOG_ERR("sdhc:req: cmd(poll) timeout int_status:%08x", reg_normal_int_stat);
+	}
+
+	return ret;
+}
+
+static int sdhc_wait_cmd_complete(struct sdhci_common *sdhci_ctx, int32_t timeout)
+{
+	k_timeout_t wait_time;
+	uint32_t events;
+	int ret = 0;
+
+	if (timeout == SDHC_TIMEOUT_FOREVER) {
+		wait_time = K_FOREVER;
+	} else {
+		wait_time = K_MSEC(timeout);
+	}
+
+	events = k_event_wait(&sdhci_ctx->irq_event,
+			      SDHCI_INT_CMD_COMPLETE | SDHCI_INT_ERROR,
+			      false, wait_time);
+
+	if (events & SDHCI_INT_ERROR) {
+		LOG_ERR("sdhc:req: cmd(irq) error int_status:%08x", events);
+		ret = -EIO;
+	} else if (!events) {
+		LOG_ERR("sdhc:req: cmd(irq) timeout");
+		ret = -ETIMEDOUT;
 	}
 
 	return ret;
@@ -653,7 +749,7 @@ static int sdhci_send_cmd(struct sdhci_common *sdhci_ctx, struct sdhc_command *c
 	bool long_resp = false;
 	uint16_t resp_type;
 	uint16_t cmd_flags;
-	int ret;
+	int ret = 0;
 
 	resp_type = (cmd->response_type & SDHC_NATIVE_RESPONSE_MASK);
 
@@ -704,7 +800,11 @@ static int sdhci_send_cmd(struct sdhci_common *sdhci_ctx, struct sdhc_command *c
 	sys_write16(SDHCI_MAKE_CMD(cmd->opcode, cmd_flags), sdhci_ctx->reg_base + SDHCI_COMMAND);
 
 	if (cmd->opcode != SD_SEND_TUNING_BLOCK) {
-		ret = sdhci_poll_cmd_complete(sdhci_ctx, cmd->timeout_ms);
+		if (sdhci_ctx->f_use_irq) {
+			ret = sdhc_wait_cmd_complete(sdhci_ctx, cmd->timeout_ms);
+		} else {
+			ret = sdhci_poll_cmd_complete(sdhci_ctx, cmd->timeout_ms);
+		}
 	}
 	if (!ret && resp_type != SD_RSP_TYPE_NONE) {
 		sdhci_cmd_done(sdhci_ctx, cmd, long_resp);
@@ -732,6 +832,7 @@ int sdhci_send_req(struct sdhci_common *sdhci_ctx, struct sdhc_command *cmd, str
 	}
 
 	sys_write32(SDHCI_INT_ALL_MASK, sdhci_ctx->reg_base + SDHCI_INT_STATUS);
+	k_event_clear(&sdhci_ctx->irq_event, SDHCI_INT_ALL_MASK);
 
 	if (cmd->opcode != SD_WRITE_SINGLE_BLOCK && cmd->opcode != SD_WRITE_MULTIPLE_BLOCK) {
 		is_read = true;
@@ -758,13 +859,21 @@ int sdhci_send_req(struct sdhci_common *sdhci_ctx, struct sdhc_command *cmd, str
 		data->block_size, data->data, data->block_addr);
 
 	if (sdhci_ctx->f_use_dma) {
-		ret = sdhci_poll_data_complete(sdhci_ctx, data->timeout_ms);
+		if (sdhci_ctx->f_use_irq) {
+			ret = sdhci_wait_data_complete(sdhci_ctx, data->timeout_ms);
+		} else {
+			ret = sdhci_poll_data_complete(sdhci_ctx, data->timeout_ms);
+		}
 
 		if (!ret && is_read) {
 			sys_cache_data_invd_range(data->data, data->blocks * data->block_size);
 		}
 	} else {
-		ret = sdhci_transfer_data(sdhci_ctx, data, is_read);
+		if (sdhci_ctx->f_use_irq) {
+			ret = sdhci_transfer_data_irq(sdhci_ctx, data, is_read);
+		} else {
+			ret = sdhci_transfer_data(sdhci_ctx, data, is_read);
+		}
 		if (ret) {
 			LOG_ERR("sdhc:req: data transfer failed (%d)", ret);
 			goto req_error;
@@ -934,8 +1043,29 @@ int sdhci_init(struct sdhci_common *sdhci_ctx)
 	/* Enable only interrupts served by the SD controller */
 	sys_write32(SDHCI_INT_DATA_MASK | SDHCI_INT_CMD_MASK,
 		    sdhci_ctx->reg_base + SDHCI_INT_ENABLE);
+
 	/* Mask all sdhci interrupt sources */
 	sys_write32(0x0, sdhci_ctx->reg_base + SDHCI_SIGNAL_ENABLE);
+	if (sdhci_ctx->f_use_irq) {
+		k_event_init(&sdhci_ctx->irq_event);
+		/* enable irqs */
+		sys_write32(SDHCI_INT_CMD_MASK | SDHCI_INT_DATA_MASK,
+			    sdhci_ctx->reg_base + SDHCI_SIGNAL_ENABLE);
+	}
 
 	return 0;
+}
+
+void sdhc_irq_cb(struct sdhci_common *sdhci_ctx)
+{
+	uint32_t irq_status;
+
+	/* save IRQ status */
+	irq_status = sys_read32(sdhci_ctx->reg_base + SDHCI_INT_STATUS);
+
+	/* clean irq status */
+	sys_write32(irq_status, sdhci_ctx->reg_base + SDHCI_INT_STATUS);
+	LOG_DBG("sdhc:irq: status %08x", irq_status);
+
+	k_event_post(&sdhci_ctx->irq_event, irq_status);
 }

--- a/drivers/sdhc/sdhci_common.h
+++ b/drivers/sdhc/sdhci_common.h
@@ -273,9 +273,11 @@ struct sdhci_common {
 	uint32_t clk_mul; /* Clock Multiplier value */
 	bool f_auto_cmd12; /* flag to Auto CMD12 Enable */
 	bool f_use_dma; /* flag to enable DMA */
+	bool f_use_irq; /* flag to enable IRQs */
 	enum sdhc_dma_select dma_mode; /* selected DMA mode */
 	struct sdhc_adma_desc *adma_descs; /* SDHC ADMA2 desc table */
 	uint32_t adma_descs_num; /* SDHC ADMA2 desc table size */
+	struct k_event irq_event; /* IRQ events */
 	/** @endcond */
 };
 
@@ -340,6 +342,22 @@ int sdhci_enable_adma2(struct sdhci_common *sdhci_ctx, struct sdhc_adma_desc *de
 static inline void sdhci_enable_auto_cmd12(struct sdhci_common *sdhci_ctx, bool enable)
 {
 	sdhci_ctx->f_auto_cmd12 = enable;
+}
+
+/**
+ * @brief Enable SDHC IRQ support.
+ *
+ * Enables SDHC IRQ support for command/data transfers.
+ * The SDHC drivers should call this API after @ref sdhci_init_caps.
+ * The consumer is responsible for SDHC IRQ requesting and enabling and should call
+ * @ref sdhc_irq_cb from its IRQ handler.
+ *
+ * @param sdhci_ctx: SDHC data context.
+ * @param enable: true to enable IRQ support.
+ */
+static inline void sdhc_enable_irq(struct sdhci_common *sdhci_ctx, bool enable)
+{
+	sdhci_ctx->f_use_irq = enable;
 }
 
 /**
@@ -477,5 +495,15 @@ int sdhci_set_uhs_timing(struct sdhci_common *sdhci_ctx, enum sdhc_timing_mode t
  */
 int sdhci_send_req(struct sdhci_common *sdhci_ctx, struct sdhc_command *cmd,
 		   struct sdhc_data *data);
+
+/**
+ * @brief SDHC IRQ handler callback.
+ *
+ * The consumer is responsible for SDHC IRQ requesting and enabling and should call
+ * @ref sdhc_irq_cb from its IRQ handler.
+ *
+ * @param sdhci_ctx: SDHC data context.
+ */
+void sdhc_irq_cb(struct sdhci_common *sdhci_ctx);
 
 #endif /* DRIVERS_SDHC_SDHCI_COMMON_H_ */

--- a/soc/arm64/bcm2712/Kconfig.defconfig
+++ b/soc/arm64/bcm2712/Kconfig.defconfig
@@ -8,7 +8,7 @@ config SOC
 
 config NUM_IRQS
 	int
-	default 280
+	default 512
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int


### PR DESCRIPTION
    This PR introduces IRQ support in generic SDHC code.
    It adds two APIs for consumer drivers:
    - sdhc_enable_irq() which has to be called to enable IRQ support
    - sdhc_irq_cb() SDHC IRQ handler callback to be called by consumer from its
    IRQ handler.
    
    The generic SDHC implementation is using k_event to pass IRQ status
    information from IRQ handler to command/data transfer routines, which are
    using k_event_wait() API to wait for required IRQ events.

 And  adds IRQ support for RPI5 bcm2712 SDHC driver. The IRQs are enabled by
    default and can be disabled with CONFIG_BRCM_BCM2712_SDHC_USE_IRQ Kconfig
    option.

Based on: https://github.com/xen-troops/zephyr/pull/120
