### PR TITLE
Zephyr v3.6.0 xt non rpi v2

### DIFF
--- a/drivers/regulator/regulator_gpio.c
+++ b/drivers/regulator/regulator_gpio.c
@@ -167,8 +167,6 @@ static int regulator_gpio_init(const struct device *dev)
 	regulator_common_data_init(dev);
 
 	for (unsigned int gpio_idx = 0; gpio_idx < cfg->num_gpios; gpio_idx++) {
-		int ret;
-
 		if (!gpio_is_ready_dt(&cfg->gpios[gpio_idx])) {
 			LOG_ERR("%s: gpio pin: %s not ready", dev->name,
 				cfg->gpios[gpio_idx].port ? cfg->gpios[gpio_idx].port->name

--- a/drivers/xen/gnttab.c
+++ b/drivers/xen/gnttab.c
@@ -372,12 +372,12 @@ static int gnttab_init(void)
 		gnttab.gref_list[0] = gref;
 	}
 
-	for (i = 0; i < CONFIG_NR_GRANT_FRAMES; i++) {
+	for (i = CONFIG_NR_GRANT_FRAMES; i; i--) {
 		xatp.domid = DOMID_SELF;
 		xatp.size = 0;
 		xatp.space = XENMAPSPACE_grant_table;
-		xatp.idx = i;
-		xatp.gpfn = xen_virt_to_gfn(gnttab_base) + i;
+		xatp.idx = i - 1;
+		xatp.gpfn = xen_virt_to_gfn(gnttab_base) + (i - 1);
 		rc = HYPERVISOR_memory_op(XENMEM_add_to_physmap, &xatp);
 		__ASSERT(!rc, "add_to_physmap failed; status = %d\n", rc);
 	}

--- a/subsys/testsuite/coverage/coverage_ram.ld
+++ b/subsys/testsuite/coverage/coverage_ram.ld
@@ -6,7 +6,7 @@
 
 /* Copied from linker.ld */
 
-#ifdef CONFIG_ARM
+#if defined(CONFIG_ARM) || defined(CONFIG_ARM64)
 SECTION_DATA_PROLOGUE(_GCOV_BSS_SECTION_NAME,(NOLOAD),)
 {
 #ifdef CONFIG_USERSPACE


### PR DESCRIPTION
Second chunk of non RPI5 patches from rpi5_dev to zephyr-v3.6.0-xt.