### PR TITLE
Fix OP-TEE driver

### DIFF
--- a/drivers/tee/optee/CMakeLists.txt
+++ b/drivers/tee/optee/CMakeLists.txt
@@ -5,4 +5,4 @@ zephyr_library()
 
 zephyr_library_sources(optee.c)
 
-zephyr_library_include_directories(${ZEPHYR_BASE}/arch/${ARCH}/include)
+zephyr_library_include_directories(${ZEPHYR_BASE}/arch/${ARCH}/include ${ZEPHYR_BASE}/kernel/include)

--- a/drivers/tee/optee/optee.c
+++ b/drivers/tee/optee/optee.c
@@ -650,11 +650,9 @@ out:
 	k_free(params);
 }
 
-static uint32_t handle_func_rpc_call(const struct device *dev, struct tee_shm *shm,
+static uint32_t handle_func_rpc_call(const struct device *dev, struct optee_msg_arg *arg,
 				     void **pages)
 {
-	struct optee_msg_arg *arg = shm->addr;
-
 	switch (arg->cmd) {
 	case OPTEE_RPC_CMD_SHM_ALLOC:
 		free_shm_pages(pages);
@@ -684,7 +682,7 @@ static uint32_t handle_func_rpc_call(const struct device *dev, struct tee_shm *s
 }
 
 static void handle_rpc_call(const struct device *dev, struct optee_rpc_param *param,
-			    void **pages)
+			    void **pages, struct optee_msg_arg *rpc_arg)
 {
 	struct tee_shm *shm = NULL;
 	uint32_t res = OPTEE_SMC_CALL_RETURN_FROM_RPC;
@@ -712,8 +710,12 @@ static void handle_rpc_call(const struct device *dev, struct optee_rpc_param *pa
 		/* Foreign interrupt was raised */
 		break;
 	case OPTEE_SMC_RPC_FUNC_CMD:
-		shm = (struct tee_shm *)regs_to_u64(param->a1, param->a2);
-		res = handle_func_rpc_call(dev, shm, pages);
+		if (!rpc_arg) {
+			shm = (struct tee_shm *)regs_to_u64(param->a1,
+							    param->a2);
+			rpc_arg = shm->addr;
+		}
+		res = handle_func_rpc_call(dev, rpc_arg, pages);
 		break;
 	default:
 		break;
@@ -765,7 +767,7 @@ static int optee_call(const struct device *dev, struct optee_msg_arg *arg, struc
 			param.a1 = res.a1;
 			param.a2 = res.a2;
 			param.a3 = res.a3;
-			handle_rpc_call(dev, &param, &pages);
+			handle_rpc_call(dev, &param, &pages, rpc_arg);
 		} else {
 			free_shm_pages(&pages);
 			return res.a0 == OPTEE_SMC_RETURN_OK ? TEEC_SUCCESS :

--- a/drivers/tee/optee/optee.c
+++ b/drivers/tee/optee/optee.c
@@ -1133,7 +1133,7 @@ static int optee_shm_register(const struct device *dev, struct tee_shm *shm)
 	msg_arg->params->u.tmem.shm_ref = (uint64_t)shm;
 	msg_arg->params->u.tmem.size = shm->size;
 
-	if (optee_call(dev, msg_arg, shm)) {
+	if (optee_call(dev, msg_arg, shm_arg)) {
 		rc = -EINVAL;
 	}
 
@@ -1165,7 +1165,7 @@ static int optee_shm_unregister(const struct device *dev, struct tee_shm *shm)
 	msg_arg->params[0].attr = OPTEE_MSG_ATTR_TYPE_RMEM_INPUT;
 	msg_arg->params[0].u.rmem.shm_ref = (uint64_t)shm;
 
-	if (optee_call(dev, msg_arg, shm)) {
+	if (optee_call(dev, msg_arg, shm_arg)) {
 		rc = -EINVAL;
 	}
 

--- a/drivers/tee/optee/optee.c
+++ b/drivers/tee/optee/optee.c
@@ -468,9 +468,10 @@ static void handle_cmd_get_time(const struct device *dev, struct optee_msg_arg *
 	}
 
 	ticks = k_uptime_ticks();
+	up_nsecs = k_ticks_to_ns_floor64(ticks);
 
-	up_secs = ticks / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-	up_nsecs = k_ticks_to_ns_floor64(ticks - up_secs * CONFIG_SYS_CLOCK_TICKS_PER_SEC);
+	up_secs = up_nsecs / Z_HZ_ns;
+	up_nsecs %= Z_HZ_ns;
 	arg->params[0].u.value.a = up_secs;
 	arg->params[0].u.value.b = up_nsecs;
 


### PR DESCRIPTION
This PR includes assorted set of patches that fixes OP-TEE in zephyr v.3.6.0

Two of them fix issues introduced by e9f7820ad78a ("drivers: tee: optee: Use SHM object cache to reduce memory ops"), which basically made OP-TEE driver inoperable when working with newer versions of OP-TEE.