### PR TITLE
Fixes for Xen grant table driver

### DIFF
--- a/drivers/xen/gnttab.c
+++ b/drivers/xen/gnttab.c
@@ -305,7 +305,7 @@ int gnttab_map_refs(struct gnttab_map_grant_ref *map_ops, unsigned int count)
 	return 0;
 }
 
-int gnttab_unmap_refs(struct gnttab_map_grant_ref *unmap_ops, unsigned int count)
+int gnttab_unmap_refs(struct gnttab_unmap_grant_ref *unmap_ops, unsigned int count)
 {
 #ifdef CONFIG_XEN_REGIONS
 	for (unsigned int i = 0; i < count; i++) {

--- a/drivers/xen/gnttab.c
+++ b/drivers/xen/gnttab.c
@@ -349,8 +349,6 @@ static int gnttab_init(void)
 {
 	grant_ref_t gref;
 	struct xen_add_to_physmap xatp;
-	struct gnttab_setup_table setup;
-	xen_pfn_t frames[CONFIG_NR_GRANT_FRAMES];
 	int rc = 0, i;
 	unsigned long xen_max_grant_frames;
 	uintptr_t gnttab_base = DT_REG_ADDR_BY_IDX(DT_INST(0, xen_xen), 0);
@@ -381,13 +379,6 @@ static int gnttab_init(void)
 		rc = HYPERVISOR_memory_op(XENMEM_add_to_physmap, &xatp);
 		__ASSERT(!rc, "add_to_physmap failed; status = %d\n", rc);
 	}
-
-	setup.dom = DOMID_SELF;
-	setup.nr_frames = CONFIG_NR_GRANT_FRAMES;
-	set_xen_guest_handle(setup.frame_list, frames);
-	rc = HYPERVISOR_grant_table_op(GNTTABOP_setup_table, &setup, 1);
-	__ASSERT((!rc) && (!setup.status), "Table setup failed; status = %s\n",
-		gnttabop_error(setup.status));
 
 	/*
 	 * Xen DT region reserved for grant table (first reg in hypervisor node)

--- a/include/zephyr/xen/gnttab.h
+++ b/include/zephyr/xen/gnttab.h
@@ -76,12 +76,12 @@ int gnttab_map_refs(struct gnttab_map_grant_ref *map_ops, unsigned int count);
  * Unmap foreign grant refs. The gnttab_put_page() should be used after this for
  * each page, that was successfully unmapped.
  *
- * @param unmap_ops - array of prepared gnttab_map_grant_ref's for unmapping
+ * @param unmap_ops - array of prepared gnttab_unmap_grant_ref's for unmapping
  * @param count - number of grefs in unmap_ops array
  * @return - @count on success or negative errno on failure
  *           also per-page status will be set in unmap_ops[i].status (GNTST_*)
  */
-int gnttab_unmap_refs(struct gnttab_map_grant_ref *unmap_ops, unsigned int count);
+int gnttab_unmap_refs(struct gnttab_unmap_grant_ref *unmap_ops, unsigned int count);
 
 /*
  * Convert grant ref status codes (GNTST_*) to text messages.


### PR DESCRIPTION
Commits in this PR fixes 2 issues in Xen grant table driver for Zephyr RTOS:
- incorrect initialization sequence
- incorrect struct, that was used during unmap of foreign grant frames

These changes will be also upstreamed to Zephyr RTOS main branch