### PR TITLE
xen: arch-arm: Sync xen_arch_domainconfig struct with xen

### DIFF
--- a/arch/arm64/core/xen/Kconfig
+++ b/arch/arm64/core/xen/Kconfig
@@ -55,3 +55,22 @@ config XEN_SYSCTL_INTERFACE_VERSION
 	  domctl interface that Zephyr will use to communicate with
 	  the hypervisor. The default value is the latest version supported
 	  by the kernel.
+
+config XEN_DOMCTL_XENTROOPS_ARCH_VGSX_OSID
+	bool "OSID used by virtual GSX device"
+	default n
+	depends on XEN
+	help
+	  Pass vGSX OSID when creating domain in struct xen_arch_domainconfig.
+	  Having matching OSID <-> DomID in place, Xen can properly recognize
+	  to what domain to inject GSX irq.
+	  Note. It is custom Xen property which is not maintained by Xen community.
+
+config XEN_DOMCTL_XENTROOPS_ARCH_SCI_TYPE
+	bool "SCI mediator framework type"
+	default n
+	depends on XEN
+	help
+	  SCI mediator framework type for creating domain in struct
+	  xen_arch_domainconfig.
+	  Note. It is custom Xen property which is not maintained by Xen community.

--- a/include/zephyr/xen/public/arch-arm.h
+++ b/include/zephyr/xen/public/arch-arm.h
@@ -316,10 +316,25 @@ DEFINE_XEN_GUEST_HANDLE(vcpu_guest_context_t);
 struct xen_arch_domainconfig {
 	/* IN/OUT */
 	uint8_t gic_version;
+#if CONFIG_XEN_DOMCTL_INTERFACE_VERSION >= 0x00000017
+	/* IN - Contains SVE vector length divided by 128 */
+	uint8_t sve_vl;
+#endif /* CONFIG_XEN_DOMCTL_INTERFACE_VERSION */
 	/* IN */
 	uint16_t tee_type;
+#ifdef CONFIG_XEN_DOMCTL_XENTROOPS_ARCH_SCI_TYPE
+	/* IN */
+	uint16_t arm_sci_type;
+#endif /* CONFIG_XEN_DOMCTL_XENTROOPS_ARCH_SCI_TYPE */
 	/* IN */
 	uint32_t nr_spis;
+#ifdef CONFIG_XEN_DOMCTL_XENTROOPS_ARCH_VGSX_OSID
+	/*
+	 * IN
+	 * OSID used by virtual GSX device.
+	 */
+	uint8_t vgsx_osid;
+#endif /* CONFIG_XEN_DOMCTL_XENTROOPS_ARCH_VGSX_OSID */
 	/*
 	 * OUT
 	 * Based on the property clock-frequency in the DT timer node.


### PR DESCRIPTION
During the attempt to run meta-xt-prod-devel-rpi5 on Raspberry Pi 5, it was discovered that `xu list` is not working properly. The output is
```
uart:~$ xu list
Name            ID   Mem VCPUs      State   Time(s)
Domain-0        0   128     1      r----       2.4
Domain-0        0 16497271373824 1698340770      -----       0.0
Domain-0        0     0 2095872      -----       0.0
```
It was found that the size of the structure xen_domctl_getdomaininfo is 120 in Zephyr, but 128 in Xen (XEN_SYSCTL_getdomaininfolist hypercall called from the domain_list). The structure xen_arch_domainconfig, which is part of xen_domctl_getdomaininfo and also xen_domctl_createdomain, in Xen has additional fields: uint8_t sve_vl, uint16_t arm_sci_type, and uint8_t vgsx_osid, which causes an issue due to data corruption.

Therefore, these fields were added to xen_arch_domainconfig to synchronize with Xen and fix an issue.

@firscity @lorc @GrygiriiS @oleksiimoisieiev 