### PR TITLE
xen: arch-arm: Fix xen version in guard macros for sve_vl field

### DIFF
--- a/include/zephyr/xen/public/arch-arm.h
+++ b/include/zephyr/xen/public/arch-arm.h
@@ -316,7 +316,7 @@ DEFINE_XEN_GUEST_HANDLE(vcpu_guest_context_t);
 struct xen_arch_domainconfig {
 	/* IN/OUT */
 	uint8_t gic_version;
-#if CONFIG_XEN_DOMCTL_INTERFACE_VERSION >= 0x00000017
+#if CONFIG_XEN_DOMCTL_INTERFACE_VERSION >= 0x00000016
 	/* IN - Contains SVE vector length divided by 128 */
 	uint8_t sve_vl;
 #endif /* CONFIG_XEN_DOMCTL_INTERFACE_VERSION */


### PR DESCRIPTION
The sve_vt field in struct xen_arch_domainconfig was added in 16 version of Xen, so it is required to change version check to more or equal of 16.

@firscity @lorc @GrygiriiS @oleksiimoisieiev