### PR TITLE
drivers: xen: add required hypercalls

### DIFF
--- a/drivers/xen/dom0/domctl.c
+++ b/drivers/xen/dom0/domctl.c
@@ -279,6 +279,30 @@ int xen_domctl_bind_pt_irq(int domid, uint32_t machine_irq, uint8_t irq_type,
 	return do_domctl(&domctl);
 }
 
+int xen_domctl_unbind_pt_irq(int domid, uint32_t machine_irq, uint8_t irq_type,
+		uint8_t bus, uint8_t device, uint8_t intx, uint8_t isa_irq,
+		uint16_t spi)
+{
+	xen_domctl_t domctl = {
+		.domain = domid,
+		.cmd = XEN_DOMCTL_unbind_pt_irq,
+	};
+	struct xen_domctl_bind_pt_irq *bind = &(domctl.u.bind_pt_irq);
+
+	switch (irq_type) {
+	case PT_IRQ_TYPE_SPI:
+		bind->irq_type = irq_type;
+		bind->machine_irq = machine_irq;
+		bind->u.spi.spi = spi;
+		break;
+	default:
+		/* TODO: implement other types */
+		return -ENOTSUP;
+	}
+
+	return do_domctl(&domctl);
+}
+
 int xen_domctl_max_vcpus(int domid, int max_vcpus)
 {
 	xen_domctl_t domctl = {

--- a/drivers/xen/dom0/sysctl.c
+++ b/drivers/xen/dom0/sysctl.c
@@ -35,6 +35,28 @@ int xen_sysctl_physinfo(struct xen_sysctl_physinfo *info)
 	return ret;
 }
 
+int xen_sysctl_tbuf_op(struct xen_sysctl_tbuf_op *tbuf_op)
+{
+	int ret;
+	xen_sysctl_t sysctl = {
+		.cmd = XEN_SYSCTL_tbuf_op,
+	};
+
+	if (!tbuf_op) {
+		return -EINVAL;
+	}
+
+	sysctl.u.tbuf_op = *tbuf_op;
+
+	ret = do_sysctl(&sysctl);
+	if (ret < 0) {
+		return ret;
+	}
+	*tbuf_op = sysctl.u.tbuf_op;
+
+	return ret;
+}
+
 int xen_sysctl_getdomaininfo(struct xen_domctl_getdomaininfo *domaininfo,
 			     uint16_t first, uint16_t num)
 {

--- a/include/zephyr/xen/dom0/domctl.h
+++ b/include/zephyr/xen/dom0/domctl.h
@@ -205,6 +205,28 @@ int xen_domctl_bind_pt_irq(int domid, uint32_t machine_irq, uint8_t irq_type, ui
 			   uint8_t device, uint8_t intx, uint8_t isa_irq, uint16_t spi);
 
 /**
+ * @brief Unbind a physical interrupt from a guest domain.
+ *
+ * Only ``PT_IRQ_TYPE_SPI`` is currently supported.
+ *
+ * @kconfig_dep{CONFIG_XEN_DOM0}
+ *
+ * @param domid Target domain identifier.
+ * @param machine_irq Machine IRQ number to unbind.
+ * @param irq_type Xen passthrough IRQ type.
+ * @param bus PCI bus number for PCI passthrough modes.
+ * @param device PCI device number for PCI passthrough modes.
+ * @param intx PCI INTx line for PCI passthrough modes.
+ * @param isa_irq ISA IRQ number for ISA passthrough modes.
+ * @param spi SPI number used with ``PT_IRQ_TYPE_SPI``.
+ *
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP @p irq_type is not supported by the current implementation.
+ */
+int xen_domctl_unbind_pt_irq(int domid, uint32_t machine_irq, uint8_t irq_type, uint8_t bus,
+			     uint8_t device, uint8_t intx, uint8_t isa_irq, uint16_t spi);
+
+/**
  * @brief Set the maximum number of vCPUs for a domain.
  *
  * The parameter passed to XEN_DOMCTL_max_vcpus must match the value passed to

--- a/include/zephyr/xen/dom0/sysctl.h
+++ b/include/zephyr/xen/dom0/sysctl.h
@@ -27,6 +27,17 @@
 int xen_sysctl_physinfo(struct xen_sysctl_physinfo *info);
 
 /**
+ * @brief Performs a Xen trace buffer sysctl operation.
+ *
+ * @param[in,out] tbuf_op A pointer to a `struct xen_sysctl_tbuf_op` object
+ *                        that defines the trace buffer operation and receives
+ *                        any output values returned by Xen.
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
+int xen_sysctl_tbuf_op(struct xen_sysctl_tbuf_op *tbuf_op);
+
+/**
  * @brief Retrieves information about Xen domains.
  *
  * @param[out] domaininfo A pointer to the `xen_domctl_getdomaininfo` structure

--- a/include/zephyr/xen/public/sysctl.h
+++ b/include/zephyr/xen/public/sysctl.h
@@ -20,6 +20,25 @@
 #include "xen.h"
 #include "domctl.h"
 
+/* Get trace buffers machine base address */
+/* XEN_SYSCTL_tbuf_op */
+struct xen_sysctl_tbuf_op {
+	/* IN variables */
+#define XEN_SYSCTL_TBUFOP_get_info     0
+#define XEN_SYSCTL_TBUFOP_set_cpu_mask 1
+#define XEN_SYSCTL_TBUFOP_set_evt_mask 2
+#define XEN_SYSCTL_TBUFOP_set_size     3
+#define XEN_SYSCTL_TBUFOP_enable       4
+#define XEN_SYSCTL_TBUFOP_disable      5
+	uint32_t cmd;
+	/* IN/OUT variables */
+	struct xenctl_bitmap cpu_mask;
+	uint32_t evt_mask;
+	/* OUT variables */
+	uint64_aligned_t buffer_mfn;
+	uint32_t size;  /* Also an IN variable! */
+};
+
 /*
  * Get physical information about the host machine
  */
@@ -133,6 +152,7 @@ struct xen_sysctl {
 #define XEN_SYSCTL_get_cpu_policy                29
 	uint32_t interface_version; /* XEN_SYSCTL_INTERFACE_VERSION */
 	union {
+		struct xen_sysctl_tbuf_op           tbuf_op;
 		struct xen_sysctl_physinfo          physinfo;
 		struct xen_sysctl_getdomaininfolist getdomaininfolist;
 		struct xen_sysctl_getcpuinfo        getcpuinfo;


### PR DESCRIPTION
drivers: xen: add domctl unbind pt irq op
Add a Dom0 wrapper for XEN_DOMCTL_unbind_pt_irq.

Use SPI-only argument handling, matching the existing bind_pt_irq wrapper.

Signed-off-by: Vladyslav Goncharuk <vladyslav_goncharuk@epam.com>

----

drivers: xen: add sysctl trace buffer op
Add the Xen sysctl trace-buffer operation ABI to the Zephyr
public Xen headers and expose a Dom0 wrapper for
XEN_SYSCTL_tbuf_op.

The wrapper follows the existing sysctl helper pattern: validate
the caller-provided request, copy it into xen_sysctl, issue
HYPERVISOR_sysctl(), and copy Xen-updated fields back on success.

Signed-off-by: Vladyslav Goncharuk <vladyslav_goncharuk@gmail.com>