### PR TITLE
arch: arm64: save Xen-provided guest FDT

### DIFF
--- a/arch/arm64/core/prep_c.c
+++ b/arch/arm64/core/prep_c.c
@@ -22,6 +22,10 @@
 #include "boot.h"
 #include "kernel_arch_func.h"
 
+#ifdef CONFIG_SAVE_XEN_FDT
+#include <zephyr/xen/fdt.h>
+#endif
+
 __weak void z_arm64_mm_init(bool is_primary_core) { }
 
 /**
@@ -40,6 +44,9 @@ FUNC_NORETURN void z_prep_c(void)
 
 	arch_bss_zero();
 	arch_data_copy();
+#ifdef CONFIG_SAVE_XEN_FDT
+	xen_copy_fdt();
+#endif /* CONFIG_SAVE_XEN_FDT */
 #ifdef CONFIG_ARM64_SAFE_EXCEPTION_STACK
 	/* After bss clean, _kernel.cpus is in bss section */
 	z_arm64_safe_exception_stack_init();

--- a/arch/arm64/core/reset.S
+++ b/arch/arm64/core/reset.S
@@ -122,6 +122,18 @@ resetwait:
 	/* Mask all exceptions */
 	msr	DAIFSet, #0xf
 
+#ifdef CONFIG_SAVE_XEN_FDT
+	mov	x1, x0
+	ldr	x0, =z_arm64_xen_fdt_addr
+	str	x1, [x0]
+
+	/* Skip 4 bytes from blob start to get fdt size */
+	add	x1, x1, #0x4
+	ldr	x0, =z_arm64_xen_fdt_size
+	ldr	w2, [x1]
+	str	w2, [x0]
+#endif /* CONFIG_SAVE_XEN_FDT */
+
 #if CONFIG_MP_MAX_NUM_CPUS > 1
 
 	/*

--- a/arch/arm64/core/xen/CMakeLists.txt
+++ b/arch/arm64/core/xen/CMakeLists.txt
@@ -6,3 +6,4 @@ zephyr_compile_options($<$<COMPILE_LANGUAGE:ASM>:-D__ASSEMBLY__>)
 
 zephyr_library_sources(hypercall.S)
 zephyr_library_sources_ifdef(CONFIG_XEN_EVENTS enlighten.c)
+zephyr_library_sources_ifdef(CONFIG_SAVE_XEN_FDT fdt.c)

--- a/arch/arm64/core/xen/Kconfig
+++ b/arch/arm64/core/xen/Kconfig
@@ -56,6 +56,21 @@ config XEN_SYSCTL_INTERFACE_VERSION
 	  the hypervisor. The default value is the latest version supported
 	  by the kernel.
 
+config SAVE_XEN_FDT
+	bool "Save Xen device tree blob on early boot"
+	depends on XEN
+	help
+	  Copy the Xen-provided guest device tree blob (passed in x0 at boot)
+	  into a static buffer early in reset so it can be parsed later.
+
+config XEN_FDT_MAX_SIZE
+	hex "Maximum Xen device tree blob size"
+	default 0x8000
+	depends on SAVE_XEN_FDT
+	help
+	  Maximum number of bytes reserved for the Xen-provided guest device
+	  tree blob saved during early boot.
+
 config XEN_DOMCTL_XENTROOPS_ARCH_VGSX_OSID
 	bool "OSID used by virtual GSX device"
 	default n

--- a/arch/arm64/core/xen/fdt.c
+++ b/arch/arm64/core/xen/fdt.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 EPAM Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/xen/generic.h>
+
+#include <zephyr/arch/common/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/linker/section_tags.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
+
+#include <zephyr/xen/fdt.h>
+
+LOG_MODULE_REGISTER(xen_fdt);
+
+#define FDT_MAGIC 0xd00dfeed
+
+/* Raw early-boot handoff from reset.S. Survives data/BSS initialization. */
+__noinit uintptr_t z_arm64_xen_fdt_addr;
+__noinit uint32_t z_arm64_xen_fdt_size;
+
+/* Validated Zephyr-owned FDT copy and CPU-endian size for runtime consumers. */
+static uint8_t xen_fdt[CONFIG_XEN_FDT_MAX_SIZE] __aligned(XEN_PAGE_SIZE);
+static uint32_t xen_fdt_size;
+
+uintptr_t get_xen_fdt_ptr(uint32_t *fdt_size)
+{
+	if (fdt_size != NULL) {
+		*fdt_size = xen_fdt_size;
+	}
+
+	return (uintptr_t)xen_fdt;
+}
+
+void xen_copy_fdt(void)
+{
+	const uint8_t *src = (const uint8_t *)z_arm64_xen_fdt_addr;
+	uint32_t magic = sys_get_be32(src);
+	uint32_t size = sys_be32_to_cpu(z_arm64_xen_fdt_size);
+
+	if (magic != FDT_MAGIC) {
+		LOG_ERR("Invalid Xen device tree magic: 0x%x", magic);
+		k_panic();
+	}
+
+	if (size > CONFIG_XEN_FDT_MAX_SIZE) {
+		LOG_ERR("Xen device tree size 0x%x exceeds max 0x%x",
+			size, CONFIG_XEN_FDT_MAX_SIZE);
+		k_panic();
+	}
+
+	arch_early_memcpy(xen_fdt, src, size);
+	xen_fdt_size = size;
+}

--- a/include/zephyr/xen/fdt.h
+++ b/include/zephyr/xen/fdt.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 EPAM Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ZEPHYR_XEN_FDT_H_
+#define ZEPHYR_INCLUDE_ZEPHYR_XEN_FDT_H_
+
+#include <stdint.h>
+
+/**
+ * @brief Return a pointer to the saved Xen-provided FDT copy.
+ *
+ * The returned pointer refers to the Zephyr-owned copy made during early boot
+ * by xen_copy_fdt(). If @p fdt_size is not NULL, it is set to the number of
+ * valid bytes in the saved copy. A reported size of 0 means no valid FDT copy
+ * has been recorded.
+ *
+ * @param fdt_size Optional output for the saved FDT size in bytes.
+ *
+ * @return Pointer to the saved FDT copy.
+ */
+uintptr_t get_xen_fdt_ptr(uint32_t *fdt_size);
+
+/**
+ * @brief Early boot hook that saves the Xen-provided boot FDT.
+ *
+ * This function is intended for the arm64 startup path. It validates the
+ * Xen-provided FDT header and copies the blob into internal storage used by
+ * get_xen_fdt_ptr(). Runtime consumers should use get_xen_fdt_ptr() instead
+ * of reading the early boot handoff symbols directly.
+ */
+void xen_copy_fdt(void);
+
+#endif /* ZEPHYR_INCLUDE_ZEPHYR_XEN_FDT_H_ */


### PR DESCRIPTION
Preserve the FDT pointer handed to the boot CPU in x0 and copy the blob
after early data initialization. Keep the path optional behind
CONFIG_SAVE_XEN_FDT so non-Xen boot flows are unchanged.

The saved copy gives Xen guest code access to the exact device tree that
the hypervisor generated for this domain. Zephyr normally consumes the
compiled-in devicetree produced at build time, so the boot-time Xen FDT
is otherwise lost before later driver or test code can inspect it.

That matters for Xen validation tests. A Zephyr guest can parse this
saved blob to check which memory ranges, interrupt mappings, grant-table
regions, event-channel information, and Xen-specific nodes were actually
supplied by the hypervisor. This lets tests validate Xen's guest
description contract from inside the running guest, instead of relying
only on host-side launch configuration.