### PR TITLE
drivers: xen: forward vcpu in context domctls

### DIFF
--- a/drivers/xen/dom0/domctl.c
+++ b/drivers/xen/dom0/domctl.c
@@ -66,7 +66,7 @@ int xen_domctl_getvcpucontext(int domid, int vcpu, vcpu_guest_context_t *ctxt)
 	xen_domctl_t domctl = {
 		.cmd = XEN_DOMCTL_getvcpucontext,
 		.domain = domid,
-		.u.vcpucontext.vcpu = 0,
+		.u.vcpucontext.vcpu = vcpu,
 	};
 
 	set_xen_guest_handle(domctl.u.vcpucontext.ctxt, ctxt);
@@ -79,7 +79,7 @@ int xen_domctl_setvcpucontext(int domid, int vcpu, vcpu_guest_context_t *ctxt)
 	xen_domctl_t domctl = {
 		.cmd = XEN_DOMCTL_setvcpucontext,
 		.domain = domid,
-		.u.vcpucontext.vcpu = 0,
+		.u.vcpucontext.vcpu = vcpu,
 	};
 
 	set_xen_guest_handle(domctl.u.vcpucontext.ctxt, ctxt);


### PR DESCRIPTION
Both public wrappers accept a vcpu argument, but the domctl request always targeted vCPU 0. Pass the caller-provided index through to Xen so getvcpucontext and setvcpucontext operate on the requested vCPU.

Xen validates the index against the domain's max_vcpus and vcpu array, so no local restriction to vCPU 0 is needed.