### PR TITLE
drivers: xen: add memory reservation wrappers

### DIFF
--- a/drivers/xen/memory.c
+++ b/drivers/xen/memory.c
@@ -52,9 +52,11 @@ int xendom_remove_from_physmap(int domid, xen_pfn_t gpfn)
 	return HYPERVISOR_memory_op(XENMEM_remove_from_physmap, &xrfp);
 }
 
-int xendom_populate_physmap(int domid, unsigned int extent_order,
-			    unsigned int nr_extents, unsigned int mem_flags,
-			    xen_pfn_t *extent_start)
+static int xendom_memory_reservation_op(unsigned int cmd, int domid,
+					unsigned int extent_order,
+					unsigned int nr_extents,
+					unsigned int mem_flags,
+					xen_pfn_t *extent_start)
 {
 	struct xen_memory_reservation reservation = {
 		.domid = domid,
@@ -65,7 +67,34 @@ int xendom_populate_physmap(int domid, unsigned int extent_order,
 
 	set_xen_guest_handle(reservation.extent_start, extent_start);
 
-	return HYPERVISOR_memory_op(XENMEM_populate_physmap, &reservation);
+	return HYPERVISOR_memory_op(cmd, &reservation);
+}
+
+int xendom_increase_reservation(int domid, unsigned int extent_order,
+				unsigned int nr_extents, unsigned int mem_flags,
+				xen_pfn_t *extent_start)
+{
+	return xendom_memory_reservation_op(XENMEM_increase_reservation, domid,
+					    extent_order, nr_extents, mem_flags,
+					    extent_start);
+}
+
+int xendom_decrease_reservation(int domid, unsigned int extent_order,
+				unsigned int nr_extents, unsigned int mem_flags,
+				xen_pfn_t *extent_start)
+{
+	return xendom_memory_reservation_op(XENMEM_decrease_reservation, domid,
+					    extent_order, nr_extents, mem_flags,
+					    extent_start);
+}
+
+int xendom_populate_physmap(int domid, unsigned int extent_order,
+			    unsigned int nr_extents, unsigned int mem_flags,
+			    xen_pfn_t *extent_start)
+{
+	return xendom_memory_reservation_op(XENMEM_populate_physmap, domid,
+					    extent_order, nr_extents, mem_flags,
+					    extent_start);
 }
 
 int xendom_acquire_resource(domid_t domid, uint16_t type, uint32_t id, uint64_t frame,

--- a/include/zephyr/xen/memory.h
+++ b/include/zephyr/xen/memory.h
@@ -53,6 +53,43 @@ int xendom_add_to_physmap_batch(int domid, int foreign_domid,
 int xendom_remove_from_physmap(int domid, xen_pfn_t gpfn);
 
 /**
+ * Increase a Xen domain's memory reservation.
+ *
+ * This asks Xen to allocate extents for the domain. On success, Xen writes the
+ * allocated machine frame bases into extent_start.
+ *
+ * @param domid		domain id whose reservation will be increased. For
+ *			unprivileged callers this should be DOMID_SELF.
+ * @param extent_order	size/alignment of each extent (size is 2^extent_order).
+ * @param nr_extents	number of extents requested.
+ * @param mem_flags	XENMEMF_* flags, or 0 when no extra flags are needed.
+ * @param extent_start	output array for allocated machine frame bases.
+ * @return		number of allocated extents on success, negative errno on
+ *			error.
+ */
+int xendom_increase_reservation(int domid, unsigned int extent_order,
+				unsigned int nr_extents, unsigned int mem_flags,
+				xen_pfn_t *extent_start);
+
+/**
+ * Decrease a Xen domain's memory reservation.
+ *
+ * This asks Xen to free guest frame extents from the domain reservation.
+ *
+ * @param domid		domain id whose reservation will be decreased. For
+ *			unprivileged callers this should be DOMID_SELF.
+ * @param extent_order	size/alignment of each extent (size is 2^extent_order).
+ * @param nr_extents	number of extents to free.
+ * @param mem_flags	XENMEMF_* flags, or 0 when no extra flags are needed.
+ * @param extent_start	input array of guest frame bases to free.
+ * @return		number of freed extents on success, negative errno on
+ *			error.
+ */
+int xendom_decrease_reservation(int domid, unsigned int extent_order,
+				unsigned int nr_extents, unsigned int mem_flags,
+				xen_pfn_t *extent_start);
+
+/**
  * Populate specified Xen domain page frames with memory.
  *
  * @param domid		domain id, where mapping will be added. For unprivileged


### PR DESCRIPTION
Add typed wrappers for XENMEM_increase_reservation and XENMEM_decrease_reservation using the existing Xen memory-op helper style. Both operations use struct xen_memory_reservation, so share the reservation setup with the existing populate-physmap wrapper.

These calls are useful for Zephyr when it runs as a Xen hardware/control domain, not as ordinary Zephyr heap management. The Xen support already exposes domain creation, maximum-memory, memory-mapping, grant-table, and event-channel control APIs. A Zephyr control-domain service or validation app needs the reservation operations to exercise the same guest memory lifecycle: ask Xen to adjust a domain reservation, receive any extent bases returned by Xen, and later return guest frames to Xen when the domain is torn down or resized.

Keep this as a typed Xen wrapper instead of adding a Zephyr memory subsystem driver. A real balloon or memory-hotplug driver would need a policy for which frames can be removed, coordination with Zephyr's allocator, and ownership of runtime memory pressure. This patch only exposes the stable Xen ABI primitive needed by that future policy and by control-domain test code.