### PR TITLE
drivers: xen: add grant table query size & grant table setup helpers

### DIFF
--- a/drivers/xen/gnttab.c
+++ b/drivers/xen/gnttab.c
@@ -372,6 +372,25 @@ int gnttab_unmap_refs(struct gnttab_unmap_grant_ref *unmap_ops, unsigned int cou
 	return HYPERVISOR_grant_table_op(GNTTABOP_unmap_grant_ref, unmap_ops, count);
 }
 
+int gnttab_query_size(domid_t dom, uint32_t *nr_frames, uint32_t *max_nr_frames,
+		      int16_t *status)
+{
+	struct gnttab_query_size query = {
+		.dom = dom,
+	};
+	int ret;
+
+	if (!nr_frames || !max_nr_frames || !status) {
+		return -EINVAL;
+	}
+
+	ret = HYPERVISOR_grant_table_op(GNTTABOP_query_size, &query, 1);
+	*nr_frames = query.nr_frames;
+	*max_nr_frames = query.max_nr_frames;
+	*status = query.status;
+
+	return ret;
+}
 
 static const char * const gnttab_error_msgs[] = GNTTABOP_error_msgs;
 

--- a/drivers/xen/gnttab.c
+++ b/drivers/xen/gnttab.c
@@ -409,16 +409,16 @@ const char *gnttabop_error(int16_t status)
 static unsigned long gnttab_get_max_frames(void)
 {
 	int ret;
-	struct gnttab_query_size q = {
-		.dom = DOMID_SELF,
-	};
+	uint32_t nr_frames;
+	uint32_t max_nr_frames;
+	int16_t status;
 
-	ret = HYPERVISOR_grant_table_op(GNTTABOP_query_size, &q, 1);
-	if ((ret < 0) || (q.status != GNTST_okay)) {
+	ret = gnttab_query_size(DOMID_SELF, &nr_frames, &max_nr_frames, &status);
+	if ((ret < 0) || (status != GNTST_okay)) {
 		return LEGACY_MAX_GNT_FRAMES_SUPPORTED;
 	}
 
-	return q.max_nr_frames;
+	return max_nr_frames;
 }
 
 static int gnttab_init(void)

--- a/drivers/xen/gnttab.c
+++ b/drivers/xen/gnttab.c
@@ -372,6 +372,27 @@ int gnttab_unmap_refs(struct gnttab_unmap_grant_ref *unmap_ops, unsigned int cou
 	return HYPERVISOR_grant_table_op(GNTTABOP_unmap_grant_ref, unmap_ops, count);
 }
 
+int gnttab_setup_table(domid_t dom, uint32_t nr_frames, xen_pfn_t *frame_list,
+		       int16_t *status)
+{
+	struct gnttab_setup_table setup = {
+		.dom = dom,
+		.nr_frames = nr_frames,
+	};
+	int ret;
+
+	if (!frame_list || !status) {
+		return -EINVAL;
+	}
+
+	set_xen_guest_handle(setup.frame_list, frame_list);
+
+	ret = HYPERVISOR_grant_table_op(GNTTABOP_setup_table, &setup, 1);
+	*status = setup.status;
+
+	return ret;
+}
+
 int gnttab_query_size(domid_t dom, uint32_t *nr_frames, uint32_t *max_nr_frames,
 		      int16_t *status)
 {

--- a/include/zephyr/xen/gnttab.h
+++ b/include/zephyr/xen/gnttab.h
@@ -93,6 +93,19 @@ int gnttab_map_refs(struct gnttab_map_grant_ref *map_ops, unsigned int count);
 int gnttab_unmap_refs(struct gnttab_unmap_grant_ref *unmap_ops, unsigned int count);
 
 /*
+ * Query current and maximum grant table size for a domain.
+ *
+ * @param dom - domain whose grant table size should be queried. Use
+ *              DOMID_SELF for the calling domain.
+ * @param nr_frames - storage where Xen writes the current frame count.
+ * @param max_nr_frames - storage where Xen writes the maximum frame count.
+ * @param status - storage where Xen writes the GNTST_* operation status.
+ * @return zero on hypercall success, negative errno on failure
+ */
+int gnttab_query_size(domid_t dom, uint32_t *nr_frames, uint32_t *max_nr_frames,
+		      int16_t *status);
+
+/*
  * Convert grant ref status codes (GNTST_*) to text messages.
  *
  * @param status - negative GNTST_* code, that needs to be converted

--- a/include/zephyr/xen/gnttab.h
+++ b/include/zephyr/xen/gnttab.h
@@ -93,6 +93,19 @@ int gnttab_map_refs(struct gnttab_map_grant_ref *map_ops, unsigned int count);
 int gnttab_unmap_refs(struct gnttab_unmap_grant_ref *unmap_ops, unsigned int count);
 
 /*
+ * Set up grant table frames for a domain.
+ *
+ * @param dom - domain whose grant table should be set up. Use DOMID_SELF for
+ *              the calling domain.
+ * @param nr_frames - minimum number of grant table frames requested.
+ * @param frame_list - storage where Xen writes @p nr_frames frame numbers.
+ * @param status - storage where Xen writes the GNTST_* operation status.
+ * @return zero on hypercall success, negative errno on failure
+ */
+int gnttab_setup_table(domid_t dom, uint32_t nr_frames, xen_pfn_t *frame_list,
+		       int16_t *status);
+
+/*
  * Query current and maximum grant table size for a domain.
  *
  * @param dom - domain whose grant table size should be queried. Use


### PR DESCRIPTION
drivers: xen: add grant table query size helper

Add gnttab_query_size() to expose GNTTABOP_query_size through the
public Xen grant table helper API.

The helper accepts operation arguments directly, builds the Xen ABI
request internally, and returns the per-operation GNTST_* status through
an output parameter.

----

drivers: xen: use grant table query size helper

Use gnttab_query_size() in the grant table initialization path instead
of calling the low-level grant table hypercall entry point directly.

This keeps the existing max-frame fallback behavior while making the
driver use the public grant table helper API for the operation it
performs during initialization.

----

drivers: xen: add grant table setup helper

Add gnttab_setup_table() to expose GNTTABOP_setup_table through the
public Xen grant table helper API.

The helper accepts operation arguments directly, builds the Xen ABI
request internally, sets the frame-list guest handle, and returns the
per-operation GNTST_* status through an output parameter.