### PR TITLE
Xen raw hypercalls v4.4.0 xt

### DIFF
--- a/arch/arm64/core/xen/hypercall.S
+++ b/arch/arm64/core/xen/hypercall.S
@@ -27,6 +27,7 @@ HYPERCALL(memory_op);
 HYPERCALL(dm_op);
 HYPERCALL(xen_version);
 HYPERCALL(vcpu_op);
+HYPERCALL(xsm_op);
 
 #ifdef CONFIG_XEN_DOM0
 HYPERCALL(domctl);

--- a/arch/arm64/core/xen/hypercall.S
+++ b/arch/arm64/core/xen/hypercall.S
@@ -26,6 +26,7 @@ HYPERCALL(hvm_op);
 HYPERCALL(memory_op);
 HYPERCALL(dm_op);
 HYPERCALL(xen_version);
+HYPERCALL(vcpu_op);
 
 #ifdef CONFIG_XEN_DOM0
 HYPERCALL(domctl);

--- a/include/zephyr/arch/arm64/hypercall.h
+++ b/include/zephyr/arch/arm64/hypercall.h
@@ -18,6 +18,7 @@ int HYPERVISOR_grant_table_op(int op, void *uop, unsigned int count);
 int HYPERVISOR_dm_op(domid_t domid, unsigned int nr_bufs, struct xen_dm_op_buf *bufs);
 int HYPERVISOR_xen_version(int op, void *param);
 int HYPERVISOR_vcpu_op(int op, unsigned int vcpuid, void *param);
+int HYPERVISOR_xsm_op(void *param);
 
 #ifdef CONFIG_XEN_DOM0
 int HYPERVISOR_domctl(void *param);

--- a/include/zephyr/arch/arm64/hypercall.h
+++ b/include/zephyr/arch/arm64/hypercall.h
@@ -17,6 +17,7 @@ int HYPERVISOR_memory_op(int op, void *param);
 int HYPERVISOR_grant_table_op(int op, void *uop, unsigned int count);
 int HYPERVISOR_dm_op(domid_t domid, unsigned int nr_bufs, struct xen_dm_op_buf *bufs);
 int HYPERVISOR_xen_version(int op, void *param);
+int HYPERVISOR_vcpu_op(int op, unsigned int vcpuid, void *param);
 
 #ifdef CONFIG_XEN_DOM0
 int HYPERVISOR_domctl(void *param);


### PR DESCRIPTION
arch: arm64: xen: add xsm_op hypercall

Expose the Xen xsm_op hypercall through the arm64 Xen hypercall
interface.

The arm64 Xen backend already keeps raw hypercall entry points in
hypercall.S and declares them in <zephyr/arch/arm64/hypercall.h>. Add
the missing xsm_op entry point there so callers that need Xen security
operations can issue the hypercall directly.

----

arch: arm64: xen: add vcpu_op hypercall

Expose the Xen vcpu_op hypercall through the arm64 Xen hypercall
interface.

The arm64 Xen backend already keeps raw hypercall entry points in
hypercall.S and declares them in <zephyr/arch/arm64/hypercall.h>. Add
the missing vcpu_op entry point there so callers that need Xen vCPU
operations can issue the hypercall directly.