### PR TITLE
drivers: xen: include stddef.h for NULL

### DIFF
--- a/drivers/xen/sched.c
+++ b/drivers/xen/sched.c
@@ -8,6 +8,7 @@
 #include <zephyr/xen/sched.h>
 
 #include <errno.h>
+#include <stddef.h>
 
 int xen_sched_yield(void)
 {


### PR DESCRIPTION
Include <stddef.h> directly in sched.c because this translation unit uses NULL when issuing sched_op hypercalls.